### PR TITLE
feat(http): Shared ClientSession через async_get_clientsession(hass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - `import base64` поднят на top of file в `camera.py` (был внутри метода) ([A-43](docs/audit/project-audit.md)).
 - Заменён `f"..."`-форматирование на `%`-форматирование в `LOGGER` вызовах (`lock.py`, `sensor.py`, `coordinator.py`).
+- **HTTP: shared `ClientSession`** через HA-стандартный `async_get_clientsession(hass)`. `HTTP.__init__` и `ElektronnyGorodAPI.__init__` принимают `hass`. Closes [A-05](docs/audit/project-audit.md) / [S-05](docs/audit/security.md). См. [ADR-0008](docs/decisions/0008-shared-client-session.md). Эффект: экономия TLS-handshake на каждом запросе, общий pool с HA-core, нет утечки сокетов в TIME_WAIT.
 
 ### Removed
 

--- a/custom_components/elektronny_gorod/api.py
+++ b/custom_components/elektronny_gorod/api.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from aiohttp import ClientResponse
 
+from homeassistant.core import HomeAssistant
+
 from .http import HTTP
 from .user_agent import UserAgent
 
@@ -16,12 +18,14 @@ class ElektronnyGorodAPI:
 
     def __init__(
         self,
+        hass: HomeAssistant,
         user_agent: UserAgent,
         access_token: str | None = None,
         refresh_token: str | None = None,
         operator: str | None = None,
     ) -> None:
         self.http: HTTP = HTTP(
+            hass,
             user_agent,
             access_token,
             refresh_token,

--- a/custom_components/elektronny_gorod/config_flow.py
+++ b/custom_components/elektronny_gorod/config_flow.py
@@ -50,7 +50,10 @@ class ElektronnyGorodConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the config flow state."""
         self.user_agent = UserAgent()
-        self.api: ElektronnyGorodAPI = ElektronnyGorodAPI(self.user_agent)
+        # self.hass устанавливается framework-ом ConfigFlow до первого async_step_*
+        # (через сеттер `hass`), но в момент __init__ ещё не инициализирован.
+        # Поэтому API создаём лениво — при первом обращении (см. @property api ниже).
+        self._api: ElektronnyGorodAPI | None = None
 
         self.entry: ConfigEntry | None = None
         self.access_token: str | None = None
@@ -63,6 +66,17 @@ class ElektronnyGorodConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Prepared entry payload to be created after the final go2rtc decision
         self._entry_data: dict[str, Any] | None = None
+
+    @property
+    def api(self) -> ElektronnyGorodAPI:
+        """Lazy-init API клиента после того, как HA установил self.hass.
+
+        Создаётся при первом обращении в любом step (например, async_step_user).
+        См. ADR-0008.
+        """
+        if self._api is None:
+            self._api = ElektronnyGorodAPI(self.hass, self.user_agent)
+        return self._api
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Collect phone or access token and start the authentication flow."""

--- a/custom_components/elektronny_gorod/coordinator.py
+++ b/custom_components/elektronny_gorod/coordinator.py
@@ -33,6 +33,7 @@ class ElektronnyGorodUpdateCoordinator(DataUpdateCoordinator):
         user_agent.from_json(json.loads(entry.data[CONF_USER_AGENT]))
 
         self._api = ElektronnyGorodAPI(
+            hass,
             user_agent,
             access_token=entry.data[CONF_ACCESS_TOKEN],
             refresh_token=entry.data[CONF_REFRESH_TOKEN],

--- a/custom_components/elektronny_gorod/http.py
+++ b/custom_components/elektronny_gorod/http.py
@@ -1,11 +1,15 @@
 """HTTP interface."""
 
-from aiohttp import ClientSession, ClientError, ClientResponse
+from aiohttp import ClientError, ClientResponse
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from ._logging import redact, is_auth_path
 from .const import (
     BASE_API_URL,
     LOGGER,
 )
-from ._logging import redact, is_auth_path
 from .user_agent import UserAgent
 
 
@@ -55,11 +59,13 @@ async def _log_response(response: ClientResponse) -> None:
 class HTTP:
     def __init__(
         self,
+        hass: HomeAssistant,
         user_agent: UserAgent,
         access_token: str | None,
         refresh_token: str | None,
         operator: str | None,
     ) -> None:
+        self._hass = hass
         self._base_url: str = f"https://{BASE_API_URL}"
         self.user_agent: UserAgent = user_agent
         self._headers: dict = {
@@ -73,37 +79,41 @@ class HTTP:
     async def __request(
         self, endpoint: str, method: str, data: object | None, binary: bool
     ) -> ClientResponse | bytes:
-        """Make a HTTP request."""
+        """Make a HTTP request through shared HA aiohttp session.
+
+        См. ADR-0008. Не создаём свою ClientSession — это нарушение HA convention
+        (audit A-05, security S-05).
+        """
         if self.access_token is not None:
             self._headers["authorization"] = f"Bearer {self.access_token}"
         self._headers["user-agent"] = str(self.user_agent)
         if method == "POST":
             self._headers["content-type"] = "application/json; charset=UTF-8"
 
-        async with ClientSession() as session:
-            url = f"{self._base_url}{endpoint}"
-            # data может быть str/bytes/None. Размер считаем безопасно.
-            if data is None:
-                body_size = 0
-            elif isinstance(data, (bytes, bytearray)):
-                body_size = len(data)
-            else:
-                body_size = len(str(data).encode("utf-8"))
-            _log_request(url, method, self._headers, body_size)
-            if method == "GET":
-                response = await session.get(url, headers=self._headers)
-            elif method == "POST":
-                response = await session.post(url, data=data, headers=self._headers)
+        session = async_get_clientsession(self._hass)
+        url = f"{self._base_url}{endpoint}"
+        # data может быть str/bytes/None. Размер считаем безопасно.
+        if data is None:
+            body_size = 0
+        elif isinstance(data, (bytes, bytearray)):
+            body_size = len(data)
+        else:
+            body_size = len(str(data).encode("utf-8"))
+        _log_request(url, method, self._headers, body_size)
+        if method == "GET":
+            response = await session.get(url, headers=self._headers)
+        elif method == "POST":
+            response = await session.post(url, data=data, headers=self._headers)
 
-            if binary:
-                return await response.read()
+        if binary:
+            return await response.read()
 
-            await _log_response(response)
-            if response.ok:
-                return response
-            else:
-                LOGGER.error("API request failed: %s [%s]", endpoint, response.status)
-                raise ClientError(response)
+        await _log_response(response)
+        if response.ok:
+            return response
+        else:
+            LOGGER.error("API request failed: %s [%s]", endpoint, response.status)
+            raise ClientError(response)
 
     async def get(self, endpoint: str, binary: bool = False) -> ClientResponse | bytes:
         """Handle GET requests."""

--- a/docs/audit/project-audit.md
+++ b/docs/audit/project-audit.md
@@ -73,11 +73,9 @@ Quality gates:
 
 ### A-05. `ClientSession` per-request
 
+- **Status:** ✅ **RESOLVED** в ветке `feat/shared-client-session` (ADR-0008). `HTTP.__init__(hass, ...)` + `async_get_clientsession(hass)` в `__request`. `ElektronnyGorodAPI.__init__` принимает `hass`. `config_flow` lazy-init API через `@property`.
 - **Area:** Performance / HA-compat
-- **Evidence:** [`http.py:56`](../../custom_components/elektronny_gorod/http.py#L56)
-- **Impact:** новый TLS-handshake на каждый запрос; не использует общий pool HA; утечка сокетов.
-- **Recommended fix:** прокинуть `hass` в `HTTP.__init__`, использовать `homeassistant.helpers.aiohttp_client.async_get_clientsession(hass)`.
-- **First step:** изменить сигнатуру `HTTP.__init__` и cascading через `ElektronnyGorodAPI` и `ElektronnyGorodUpdateCoordinator`.
+- **Original Impact:** новый TLS-handshake на каждый запрос; не использовал общий pool HA; утечка сокетов.
 - **Owner agent:** Architecture.
 
 ### A-06. Bug в `update_camera_state`: поиск по `"ID"` вместо `"id"`
@@ -395,6 +393,14 @@ Quality gates:
 - **Impact:** требует APK reverse engineering для FCM project_id, sender_id, server_key. Юридически серая зона. **Не делать** в рамках HA-интеграции, если есть альтернативы через WS/SIP.
 - **Status:** оставляем как known endpoint в `api-reference.md`. Реализация не планируется.
 
+### A-55. Unread response body в `request_sms_code`
+
+- **Severity:** P2 (выявлен code-reviewer-ом во время review ветки `feat/shared-client-session`).
+- **Evidence:** [`api.py:request_sms_code`](../../custom_components/elektronny_gorod/api.py) (около строк 93-117) — после `await self.http.post(...)` метод просто `return` без чтения body. С прежним per-request `ClientSession` connection закрывался автоматически при exit `async with`. С shared session (после ADR-0008) — connection возвращается в pool только после consume body или GC.
+- **Impact:** под нагрузкой может удерживать connection в "in-use" состоянии дольше необходимого. Не блокер, но slightly менее эффективно.
+- **Recommended fix:** добавить `await response.read()` перед `return` либо использовать pattern `async with response:` для гарантированного освобождения connection. Сгруппировать с A-19/A-20 в одном PR.
+- **Target:** Итерация 3 Bronze (slice 3e, вместе с tighter exception handling).
+
 ## Maintenance rules (повтор)
 
 См. [`PROJECT_MAP.md#maintenance-rules`](../project/project-map.md#maintenance-rules).
@@ -405,7 +411,7 @@ Quality gates:
 |---|---|
 | A-01..A-05, A-43, A-45 | Итерация 1 (hotfix-релиз) |
 | A-06, A-07 | Итерация 1 |
-| A-08..A-14, A-16..A-21, A-23, A-24, A-44 | Итерация 2 |
+| A-08..A-14, A-16..A-21, A-23, A-24, A-44, A-55 | Итерация 2 |
 | A-15, A-22, A-25, A-26, A-37, A-38, A-48, A-51, A-52 | Итерация 3 |
 | A-47, A-49, A-50 | Итерация 4 (real-time + push) — после доп. HAR-research |
 | A-27..A-36, A-39..A-41, A-53, A-54 | по мере touch / документирование |

--- a/docs/audit/security.md
+++ b/docs/audit/security.md
@@ -89,10 +89,9 @@ Quality gates:
 
 ### S-05. Per-request `ClientSession` без `async_get_clientsession`
 
-- **Файл:** [`http.py:56`](../../custom_components/elektronny_gorod/http.py#L56)
-- **Severity:** P0 (Reliability / Performance, не утечка, но кросс-разрез)
-- **Impact:** каждый запрос — новый TLS handshake, отсутствует общий pool HA, рост сокетов в TIME_WAIT, медленные ответы.
-- **Fix:** прокинуть `hass` в `HTTP.__init__` и использовать `async_get_clientsession(hass)`.
+- **Status:** ✅ **RESOLVED** в ветке `feat/shared-client-session` (ADR-0008). `HTTP.__init__(hass, ...)` + `async_get_clientsession(hass)` в `__request`. См. [audit A-05](project-audit.md).
+- **Severity:** P0 (Reliability / Performance)
+- **Original Impact:** каждый запрос — новый TLS handshake, отсутствовал общий pool HA, рост сокетов в TIME_WAIT, медленные ответы.
 
 ## P1 — важные
 

--- a/docs/decisions/0008-shared-client-session.md
+++ b/docs/decisions/0008-shared-client-session.md
@@ -1,0 +1,109 @@
+# ADR-0008: Shared `ClientSession` через `async_get_clientsession(hass)`
+
+- **Status:** accepted
+- **Date:** 2026-05-24
+- **Owner:** Architecture + HA Expert Agent
+
+## Context
+
+Сейчас [`http.py:56`](../../custom_components/elektronny_gorod/http.py#L56) создаёт `aiohttp.ClientSession()` **per-request**:
+
+```python
+async with ClientSession() as session:
+    ...
+```
+
+Это нарушает HA-конвенцию ([audit A-05](../audit/project-audit.md), [security S-05](../audit/security.md)). На каждый HTTP-запрос:
+- новый TCP + TLS handshake (~50-200ms);
+- новый connector pool (нет HTTP/2 multiplexing, нет keep-alive reuse);
+- накопление сокетов в `TIME_WAIT` после закрытия;
+- невозможность HA-core централизованно ограничивать concurrent requests / monitoring.
+
+Home Assistant предоставляет `homeassistant.helpers.aiohttp_client.async_get_clientsession(hass)` — общий pool на весь HA-инстанс. Это стандарт для **всех** интеграций.
+
+## Decision
+
+Прокинуть `hass: HomeAssistant` через слои `Coordinator → API → HTTP` и использовать `async_get_clientsession(hass)` в `HTTP.__request`.
+
+### Изменения сигнатур
+
+```python
+class HTTP:
+    def __init__(
+        self,
+        hass: HomeAssistant,       # ← новое
+        user_agent: UserAgent,
+        access_token: str | None,
+        refresh_token: str | None,
+        operator: str | None,
+    ) -> None:
+        self._hass = hass
+        ...
+
+class ElektronnyGorodAPI:
+    def __init__(
+        self,
+        hass: HomeAssistant,       # ← новое
+        user_agent: UserAgent,
+        access_token: str | None = None,
+        refresh_token: str | None = None,
+        operator: str | None = None,
+    ) -> None:
+        self.http = HTTP(hass, user_agent, access_token, refresh_token, operator)
+        ...
+```
+
+В `HTTP.__request`:
+
+```python
+session = async_get_clientsession(self._hass)
+# больше НЕ `async with ClientSession() as session:`
+if method == "GET":
+    response = await session.get(url, headers=self._headers)
+elif method == "POST":
+    response = await session.post(url, data=data, headers=self._headers)
+```
+
+Важно: **не закрывать** session через `async with` или `session.close()` — это shared pool, его lifecycle управляется HA-core.
+
+### Места вызовов
+
+- `coordinator.py:__init__` — `ElektronnyGorodAPI(hass, user_agent, ...)`. `hass` уже есть в этой функции.
+- `config_flow.py:__init__` — `ElektronnyGorodAPI(self.hass, self.user_agent)`. `self.hass` доступен в `ConfigFlow`.
+
+## Consequences
+
+### Positive
+
+- Закрывает [audit A-05](../audit/project-audit.md), [security S-05](../audit/security.md).
+- Экономия TLS handshake (~50-200ms per request) — заметно при последовательной серии snapshot-запросов камер.
+- Нет утечки сокетов в `TIME_WAIT`.
+- Согласуется с HA Bronze IQS требованиями.
+- Совместимо с будущим `ClientTimeout` (A-21) — `async_get_clientsession(hass)` возвращает session, в которой можно передать timeout через каждый request.
+
+### Negative
+
+- **Breaking change** для внутреннего API `HTTP.__init__` / `ElektronnyGorodAPI.__init__` (новый параметр `hass`). На существующих интеграциях не сломается, т.к. вызовы только из `coordinator.py` и `config_flow.py` (внутренние).
+- Тесты, которые инстанцируют `HTTP` / `API` напрямую (будущие в Этапе 3 Bronze) должны передавать mock-hass.
+
+### Mitigation
+
+- Сигнатуры обновлены атомарно — один commit, никаких поэтапных deprecations внутри проекта.
+- HA-core mock через `pytest-homeassistant-custom-component` предоставит совместимый `hass`.
+
+## Alternatives considered
+
+1. **Создать одну `ClientSession` в `HTTP.__init__` и переиспользовать без `hass`.** Отклонено — не идиоматично для HA, ломает закрытие на unload, не использует HA-core monitoring.
+2. **Lazy session per HTTP instance**, кэшированная в self.\_session. Отклонено — то же.
+3. **Использовать `async_create_clientsession(hass)` вместо `async_get_clientsession(hass)`** (создание своей session с custom-конфигом). Отклонено — нам не нужен custom-конфиг сейчас; shared pool достаточно.
+
+## Supersedes / Superseded by
+
+—
+
+## Notes
+
+- Связано с [ADR-0002](0002-coordinator-pattern.md) (coordinator pattern) — A-05 нужно решить **до** реализации ADR-0002, чтобы новый CoordinatorEntity не наследовал плохой паттерн.
+- Audit IDs закрываемые: A-05 (P0 — performance/HA-compat), S-05 (security — связано с реликвиями).
+- Не закрывает A-21 (`ClientTimeout`) — отдельная задача в Этапе 3 Bronze.
+- Не закрывает A-19/A-20 (узкие исключения) — отдельная задача.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,10 +18,11 @@
 | [0001](0001-aidd-adoption.md) | Принятие AIDD | accepted | 2026-05-22 |
 | [0002](0002-coordinator-pattern.md) | Переход на CoordinatorEntity + update_interval | proposed | 2026-05-22 |
 | [0003](0003-iot-class-strategy.md) | Стратегия `iot_class` и polling | proposed | 2026-05-22 |
-| [0004](0004-token-redaction.md) | Token redaction в логах | proposed | 2026-05-22 |
+| [0004](0004-token-redaction.md) | Token redaction в логах | **accepted** (реализован в hotfix PR #31) | 2026-05-22 |
 | [0005](0005-lock-vs-button.md) | Lock vs Button для домофона | proposed | 2026-05-22 |
 | [0006](0006-mirror-app-behavior.md) | Mirror application behavior | accepted | 2026-05-23 |
 | [0007](0007-stateful-emulator-baseline.md) | Stateful emulator baseline для HAR-сбора | accepted | 2026-05-23 |
+| [0008](0008-shared-client-session.md) | Shared `ClientSession` через `async_get_clientsession(hass)` | accepted | 2026-05-24 |
 
 ## Когда писать ADR
 


### PR DESCRIPTION
## Summary

Реализация [ADR-0008](docs/decisions/0008-shared-client-session.md). Закрывает [A-05](docs/audit/project-audit.md) / [S-05](docs/audit/security.md) — P0 audit findings из первого аудита.

## What changed

Замена per-request `aiohttp.ClientSession()` на shared session через HA-стандартный `async_get_clientsession(hass)`.

### Сигнатуры

```python
# Было
HTTP(user_agent, access_token, refresh_token, operator)
ElektronnyGorodAPI(user_agent, access_token=..., ...)

# Стало
HTTP(hass, user_agent, access_token, refresh_token, operator)
ElektronnyGorodAPI(hass, user_agent, access_token=..., ...)
```

### Lazy-init в config_flow

`self.hass` устанавливается framework-ом ConfigFlow **до** первого `async_step_*`, но **не доступен в `__init__`**. Поэтому API создаётся через `@property api` при первом обращении.

### Прокидывание

- `coordinator.py` — передаёт `hass` (доступен из `DataUpdateCoordinator`).
- `config_flow.py` — lazy через `@property`.

## Effect

- TLS-handshake экономия ~50-200ms per request.
- Общий connection pool с HA-core (HTTP/2 multiplexing, keep-alive reuse).
- Нет утечки сокетов в TIME_WAIT.
- HA Bronze IQS требование выполнено.

## Bonus side-effect

Прежний `async with ClientSession() as session:` возвращал `response` после exit context-manager — это **латентный bug** (response может быть consumed). Новый код возвращает `response` без exit. По факту это улучшение корректности.

## Out of scope

- `ClientTimeout` (A-21) — Итерация 3.
- Узкие exceptions + правильный `ClientError → ClientResponseError` (A-19/A-20) — Итерация 3.
- A-55: `request_sms_code` не читает response body (выявлено code-reviewer-ом во время review этого PR) — Итерация 3 в одной партии с A-19/A-20.

## Test plan

- [x] Syntax check на всех изменённых файлах.
- [x] `grep ClientSession()` — нет прямых вызовов.
- [x] `grep ElektronnyGorodAPI(` — все вызовы включают `hass`.
- [x] Code review через `comprehensive-review:code-reviewer` — **Approve with comments** (nit поправлен, follow-up зафиксирован).
- [ ] hassfest CI.
- [ ] HACS validate CI.
- [ ] prerelease.yaml выкатит zip с тегом `pr-N` для пользовательского теста.
- [ ] Pytest для config_flow / coordinator / api — будет добавлен в Этапе 3 Bronze (slice 3e). Сейчас тестов на эти модули нет, и они зависят от `pytest-homeassistant-custom-component`, которого пока нет в репо.

## After merge

Этап 3 — Bronze IQS (slices 3a..3f). Начнём с slice 3a (coordinator pattern: `update_interval` + dict-based data + ACCEPT ADR-0002/0003).

🤖 Generated with [Claude Code](https://claude.com/claude-code)