### PR TITLE
docs(audit+roadmap): post-3.1.0 sync — close resolved, add 7 findings, rewrite Iter 4

### DIFF
--- a/docs/audit/project-audit.md
+++ b/docs/audit/project-audit.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: Lead Architect Agent
-Last reviewed: 2026-05-22
+Last reviewed: 2026-05-25
 
 Source files:
 - `custom_components/elektronny_gorod/**`
@@ -27,7 +27,7 @@ Quality gates:
 
 # Project Audit — все находки с приоритетами
 
-Все известные на 2026-05-22 проблемы. Каждая запись имеет evidence, рекомендуемый fix и first step.
+Все известные проблемы. Каждая запись имеет evidence, рекомендуемый fix и first step. Дата актуальности — `Last reviewed:` во фронт-блоке.
 
 ## Приоритеты
 
@@ -86,7 +86,7 @@ Quality gates:
 
 ### A-07. Тесты — нерабочий stub из шаблона HA
 
-- **Status:** ✅ **PARTIALLY RESOLVED**. Stub `tests/test_config_flow.py` удалён. Добавлен реальный `tests/test_logging_redact.py` для нового helper'а. Полноценный test plan для config_flow + coordinator + api → Этап 3 Bronze (slice 3e).
+- **Status:** ✅ **RESOLVED**. Stub `tests/test_config_flow.py` удалён. Добавлены реальные тесты: `tests/test_logging_redact.py` (redaction helpers), `tests/test_http.py` (HTTP client + Bearer-omission на pre-auth), `tests/test_entity_migration.py` (lock unique_id migration), `tests/test_visibility.py` + `tests/test_visibility_real.py` (visibility sync). `tests/conftest.py` использует `auto_enable_custom_integrations` фикстуру, `pytest.ini` сконфигурирован. Локально 67 tests pass. CI workflow `.github/workflows/python-tests.yaml` — открытый follow-up (см. A-24 / Tests-1).
 - **Area:** Testing / Correctness
 
 ## P1 — важные
@@ -154,12 +154,13 @@ Quality gates:
 
 ### A-17. Дубликат логики в coordinator
 
-- **Status:** ✅ **RESOLVED** в ветке `feat/coordinator-pattern` (slice 3a). Извлечён `_collect_cameras_for_place(place_id)` helper. Прежние `get_cameras_info` и `update_camera_state` больше не дублируют сбор камер — они являются shim-ами над `self.data`.
+- **Status:** ✅ **RESOLVED**. Извлечён `_collect_cameras_for_place(place_id)` helper в `coordinator.py` (плюс симметричный `_collect_locks_for_place`). Прежние `get_cameras_info` и `update_camera_state` shim-ы удалены — entities читают `coordinator.data` напрямую.
 - **Area:** Maintainability
+- **Follow-up:** см. A-61 — `_collect_locks_for_place` и `_collect_cameras_for_place` повторно тянут `query_screens_settings` + `query_access_controls` для одного place. Оставшийся duplicate уже на следующем уровне (per-place fan-out, не per-call).
 
 ### A-18. `available_sections` извлекается и игнорируется
 
-- **Status:** ✅ **RESOLVED** в ветке `feat/coordinator-pattern` (slice 3a). Вызов `query_sections` удалён из coordinator (он действительно был неиспользуемым — endpoint `/rest/v1/places/{p}/screen-sections` возвращает UI-конфиг приложения, не нужный HA-интеграции).
+- **Status:** ✅ **RESOLVED**. Вызов `query_sections` удалён из coordinator (endpoint `/rest/v1/places/{p}/screen-sections` возвращает UI-конфиг приложения, не нужный HA-интеграции). Подтверждение — в [`coordinator.py:_async_update_data`](../../custom_components/elektronny_gorod/coordinator.py) больше нет упоминаний `available_sections` / `query_sections`.
 - **Area:** Dead code / Performance
 
 ### A-19. Широкий `except Exception` в API + `e.args[0]`
@@ -183,8 +184,9 @@ Quality gates:
 
 ### A-22. Поведение при 401 (auto-refresh — unknown)
 
+- **Status:** 🟡 **PARTIALLY RESOLVED**. Подзадача «pre-auth endpoints НЕ должны получать stale Bearer» закрыта — [`http.py`](../../custom_components/elektronny_gorod/http.py) (комментарий «Bearer НЕ шлём на pre-auth endpoints (/auth/*) — иначе backend видит expired Bearer и отдаёт 401 даже на login, блокируя reauth flow»). Покрыто `tests/test_http.py`. Это разблокировало возможность native reauth flow (см. A-25).
 - **Area:** UX / Reliability
-- **Evidence:** [`api.py:160-162`](../../custom_components/elektronny_gorod/api.py#L160-L162) — при 401 поднимается `ValueError("unauthorized")` без попытки refresh.
+- **Что осталось:** собственно `/auth/.../refresh` endpoint и его триггер по 401 в hot path — **по-прежнему не реализован**. Native `async_step_reauth_confirm` не написан (см. A-25). Пользователь при истечении access_token увидит сначала UpdateFailed, затем должен переинициализировать config_entry.
 - **Note:** оригинальное приложение **в наблюдавшихся HAR-сессиях** не использует `/auth/.../refresh` endpoint. Это **не значит** что endpoint не существует — возможно, мы не поймали сценарий истечения access_token. См. [ADR-0006](../decisions/0006-mirror-app-behavior.md).
 - **Текущая рекомендация:** **не реализовывать** auto-refresh «по интуиции». Сначала — собрать HAR со сценарием истечения access_token (запуск приложения после долгого простоя / форсированный logout-on-server). Только после этого — реализовывать в точном соответствии с приложением.
 - **Fallback пока HAR нет:** при 401 — graceful UpdateFailed, пользователь проходит reauth через UI. Это сейчас и работает.
@@ -394,6 +396,146 @@ Quality gates:
 - **Recommended fix:** добавить `await response.read()` перед `return` либо использовать pattern `async with response:` для гарантированного освобождения connection. Сгруппировать с A-19/A-20 в одном PR.
 - **Target:** Итерация 3 Bronze (slice 3e, вместе с tighter exception handling).
 
+## Findings из второго HAR-research цикла + PR #35
+
+> Источник — HAR-research циклы (gitignored снимки в `research/api/*.har`)
+> + PR #35 «visibility sync + Bronze entity polish». Все находки подкреплены
+> либо HAR, либо новым кодом в `coordinator.py` / `__init__.py`.
+
+### A-56. DND switches не реализованы
+
+- **Severity:** P2 (Silver-уровневая feature).
+- **Area:** Feature gap.
+- **Evidence:** `GET|POST /api/mh-customer/.../settings/do_not_disturb` —
+  см. [`api-reference.md` §do_not_disturb](../architecture/api-reference.md).
+  Endpoint возвращает массив из трёх settings: `DO_NOT_DISTURB_ROOT` (master)
+  + `INTERCOM_CALLS` и `MANAGEMENT_COMPANY_CALLS` (dependent).
+- **Semantics (подтверждено пользователем):** master + 2 dependent, по
+  default OFF. При `DO_NOT_DISTURB_ROOT.status=false` dependent switch-и
+  скрыты в UI приложения; при включении master — появляются и оба тоже OFF
+  по дефолту.
+- **Impact:** интеграция не управляет уведомлениями (звонки домофона
+  / новости от УК). Не блокер, но это user-facing feature, доступная в
+  оригинальном приложении одним switch.
+- **Recommended fix:** новая платформа `switch` (3 entity per place):
+  `switch.dnd_root` (всегда available), `switch.dnd_intercom_calls` и
+  `switch.dnd_management_company_calls` (`_attr_available =
+  coordinator.data["dnd"][place_id]["root"]["status"]`). Coordinator
+  fetches DND state в `_async_update_data`. Switch state toggle → POST
+  массива объектов (без обёртки `{do_not_disturb: ...}`).
+
+### A-57. Sensor balance — нет дополнительных attrs из `/finance` response
+
+- **Severity:** P2 (Silver UX).
+- **Area:** Feature gap.
+- **Evidence:** `/api/mh-payment/mobile/v1/finance` response содержит:
+  `balance, blockType, amountSum, targetDate, paymentLink, daysToBlock,
+  daysToWarning, company, blocked` — см.
+  [`api-reference.md` §finance](../architecture/api-reference.md). Coordinator
+  уже извлекает большинство этих полей (`coordinator.py:_fetch_balance`),
+  но sensor использует только `balance` как native_value.
+- **Impact:** пользователь не может easily автоматизировать «оплати счёт»
+  (нет binary_sensor) или предупредить «скоро блокировка» (нет
+  `days_to_block`). API-данные уже на руках в `coordinator.data`.
+- **Recommended fix (несколько entities):**
+  - `binary_sensor.balance_blocked` (BinarySensorDeviceClass.PROBLEM) —
+    из `blocked: bool`.
+  - `sensor.balance_days_to_block` — из `daysToBlock` (когда не null).
+  - `sensor.balance_next_payment_amount` (MONETARY) — из `amountSum`.
+  - `sensor.balance_next_payment_date` (TIMESTAMP) — из `targetDate`.
+  - `button.balance_pay` — открывает `paymentLink` в браузере.
+- Группировать в одном PR — один coordinator dict-key, один device,
+  пять entities.
+
+### A-58. `/rest/v1/events/search` polling не реализован
+
+- **Severity:** P1 (основа Silver real-time без APK реверса).
+- **Area:** Feature gap / real-time alternative.
+- **Evidence:** `POST /rest/v1/events/search?page={n}&sort=occurredAt,DESC`
+  с body `{placeIds: [<PLACE_ID>]}` — см.
+  [`api-reference.md` §events](../architecture/api-reference.md). Spring Pageable,
+  retention ~6 месяцев, page size = 20, `last:true` означает исчерпание.
+- **Impact:** **реалистичная альтернатива STOMP/FCM** для real-time event
+  detection в HA. Latency 15-30s (polling interval) acceptable для
+  большинства автоматизаций («звонок в домофон → подсветить экран»,
+  «motion → уведомление»). Не требует STOMP-клиента или APK реверса.
+- **Recommended fix:** coordinator polls `/events/search?page=0` каждые
+  15-30 сек (отдельный interval, **не** общий 5-минутный refresh) →
+  dedup по `id` → `async_dispatcher_send` для новых событий → HA `event`
+  entity на каждый camera/access_control. Backfill при первом setup —
+  опционально (до 6 месяцев истории в logbook).
+- **ADR:** требуется новый **ADR-0009** (см. §«ADR кандидаты» в roadmap)
+  до начала имплементации — зафиксировать почему отказались от STOMP/FCM
+  в пользу polling.
+
+### A-59. Video archive retention не учитывается при формировании URL
+
+- **Severity:** P3 (UX improvement).
+- **Area:** Correctness.
+- **Evidence:** Video retention зависит от типа камеры — 14d для
+  intercoms (accessControl source), 7d для PUBLIC_CAMERA. Rolling-window
+  («граница ползёт» по wall-clock). См.
+  [`api-reference.md` §retention](../architecture/api-reference.md).
+- **Impact:** интеграция при попытке получить video URL за пределами
+  retention окна получит 500 с `errorCode 11005` («archive out of range»).
+  Это ложная error для пользователя — данных физически нет, но HA
+  показывает «video стримминг недоступен / ошибка».
+- **Recommended fix:** helper `is_within_retention(camera_type, ts) -> bool`
+  в `helpers.py` (mapping retention per source type) + проверка перед
+  любым video URL request. Если вне retention — возвращать `None` (или
+  раннее `UpdateFailed` с понятной причиной), не дёргать API.
+
+### A-60. Visibility migration v2 уже applied
+
+- **Status:** ✅ **RESOLVED** (документируется для будущих изменений).
+- **Area:** Migration / Documentation.
+- **Evidence:** [`__init__.py:_migrate_legacy_disabled_state`](../../custom_components/elektronny_gorod/__init__.py)
+  — one-time миграция, флаг `entry.options.visibility_migration_v2`.
+  Сбрасывает legacy `disabled_by` markers (entity + device, level
+  INTEGRATION/DEVICE/USER) → `None`. Применяется один раз per entry.
+- **Impact / зачем фиксировать:** будущие изменения visibility-логики
+  должны помнить, что flag `visibility_migration_v2` уже expended на
+  всех existing entries. Если потребуется новая cleanup-стадия —
+  использовать новый flag-ключ (`visibility_migration_v3` и т.д.),
+  не reuse old.
+
+### A-61. Двойной HTTP в per-place collectors
+
+- **Severity:** P3 (perf, не функциональная проблема).
+- **Area:** Performance.
+- **Evidence:** [`coordinator.py:_collect_locks_for_place`](../../custom_components/elektronny_gorod/coordinator.py)
+  повторно вызывает `query_screens_settings` и `query_access_controls`,
+  которые уже были fetched в `_collect_cameras_for_place` для того же
+  place. В самом коде есть TODO-комментарий: «это +1 HTTP per place per
+  refresh. TODO: вынести screens на верхний уровень».
+- **Impact:** +2 HTTP per place per refresh (screens + access_controls).
+  При 5-минутном update_interval и N places — 2N лишних requests
+  каждые 5 минут. Это **не** функциональная проблема (данные одинаковые,
+  results корректные), а излишняя нагрузка на оператора + лишний latency.
+- **Recommended fix:** в `_async_update_data` для каждого place fetch
+  screens + access_controls один раз → передавать в `_collect_cameras_for_place`
+  и `_collect_locks_for_place` как параметры (вместо повторного fetch
+  внутри). От code-reviewer hand-off.
+
+### A-62. FAVORITES section в `/settings/screens` не парсится
+
+- **Severity:** P3 (correctness, fallback OK).
+- **Area:** Feature gap / Correctness.
+- **Evidence:** [`coordinator.py:_extract_hidden_ids`](../../custom_components/elektronny_gorod/coordinator.py)
+  парсит только `PUBLIC_CAMERAS` и `ACCESS_CONTROLS` секции. Секция
+  `FAVORITES` (см.
+  [`api-reference.md` §screens](../architecture/api-reference.md))
+  игнорируется. FAVORITES может иметь mixed entity-types (camera +
+  access_control_entrance) — отдельная семантика «избранное на главном
+  экране приложения».
+- **Impact:** у наших пользователей FAVORITES.hidden обычно пуст
+  (исходя из observed HAR-снимков), поэтому fallback на PUBLIC_CAMERAS +
+  ACCESS_CONTROLS даёт корректный результат. Но если пользователь явно
+  скрыл что-то через FAVORITES в приложении — мы это не учтём.
+- **Recommended fix:** расширить `_extract_hidden_ids` чтобы умело
+  парсить FAVORITES с учётом mixed-typed items (item.type → camera /
+  entrance), затем union с уже извлечёнными hidden_ids. Не блокер.
+
 ## Maintenance rules (повтор)
 
 См. [`PROJECT_MAP.md#maintenance-rules`](../project/project-map.md#maintenance-rules).
@@ -403,10 +545,12 @@ Quality gates:
 | Audit ID | Итерация в [`roadmap.md`](../roadmap.md) |
 |---|---|
 | A-01..A-05, A-43, A-45 | Итерация 1 (hotfix-релиз) |
-| A-06, A-07 | Итерация 1 |
-| A-08..A-14, A-16..A-21, A-23, A-24, A-44, A-55 | Итерация 2 |
-| A-15, A-22, A-25, A-26, A-37, A-38, A-48, A-51, A-52 | Итерация 3 |
-| A-47, A-49, A-50 | Итерация 4 (real-time + push) — после доп. HAR-research |
+| A-06, A-07 | Итерация 1-2 (test infra доехала с Bronze polish) |
+| A-08..A-14, A-16..A-21, A-23, A-24, A-44, A-55 | Итерация 2 (Bronze IQS — shipped в 3.1.0) |
+| A-60 | Итерация 2 (visibility migration v2 — shipped в 3.1.0) |
+| A-15, A-22 (остаток), A-25, A-26, A-37, A-38, A-48, A-51, A-52 | Итерация 3 |
+| A-56, A-57, A-58, A-59, A-61, A-62 | Итерация 3 (Silver feature gaps) |
+| A-58 + A-47 (понижен), A-49, A-50 | Итерация 4 (real-time event detection — polling-first) |
 | A-27..A-36, A-39..A-41, A-53, A-54 | по мере touch / документирование |
 | A-42, A-46 | информация (не задача) |
 

--- a/docs/project/project-map.md
+++ b/docs/project/project-map.md
@@ -122,17 +122,17 @@ elektronny-gorod/
 
 | Файл | Назначение | Особенности |
 |---|---|---|
-| [`coordinator.py`](../../custom_components/elektronny_gorod/coordinator.py) | `DataUpdateCoordinator` | 🔴 **Без `update_interval`** — однократная загрузка `_subscriber_places` |
-| [`api.py`](../../custom_components/elektronny_gorod/api.py) | REST endpoints: auth, profile, places, access controls, cameras, locks, balance | использует свой `HTTP` |
-| [`http.py`](../../custom_components/elektronny_gorod/http.py) | низкоуровневый HTTP | 🔴 **per-request `ClientSession()`** |
+| [`coordinator.py`](../../custom_components/elektronny_gorod/coordinator.py) | `DataUpdateCoordinator` | `update_interval=5min`, `_async_update_data` → `{places, balances, cameras, locks}` (ADR-0002) |
+| [`api.py`](../../custom_components/elektronny_gorod/api.py) | REST endpoints: auth, profile, places, access controls, cameras, locks, balance, screens, finance | использует shared `HTTP` (ADR-0008) |
+| [`http.py`](../../custom_components/elektronny_gorod/http.py) | низкоуровневый HTTP | shared `async_get_clientsession(hass)` (ADR-0008); per-request copy headers; Bearer не шлётся на `/auth/*`; `redact_path()` в error log |
 
 ### Платформы (entity)
 
 | Файл | Платформа | Особенности |
 |---|---|---|
-| [`camera.py`](../../custom_components/elektronny_gorod/camera.py) | `camera` | STREAM, опциональный proxy через go2rtc |
-| [`lock.py`](../../custom_components/elektronny_gorod/lock.py) | `lock` | fake-timer через `asyncio.sleep` |
-| [`sensor.py`](../../custom_components/elektronny_gorod/sensor.py) | `sensor` | balance, unit "₽" (вместо RUB) |
+| [`camera.py`](../../custom_components/elektronny_gorod/camera.py) | `camera` | `CoordinatorEntity`, stable `unique_id=elektronny_gorod_camera_{id}`, STREAM + опциональный proxy через go2rtc, intercom-камера группируется с lock через entrance_uid |
+| [`lock.py`](../../custom_components/elektronny_gorod/lock.py) | `lock` | `CoordinatorEntity`, stable `unique_id=elektronny_gorod_lock_{place}_{ac}_{eid\|main}`, synthetic state через `async_call_later` (без блокировки event loop) |
+| [`sensor.py`](../../custom_components/elektronny_gorod/sensor.py) | `sensor` | balance, `device_class=MONETARY` + `state_class=TOTAL` + `unit=RUB` (long-term statistics); `_attr_translation_key="balance"`, имя из `device_info.name` |
 
 ### Внешние интеграции
 
@@ -161,8 +161,13 @@ elektronny-gorod/
 
 | Файл | Статус |
 |---|---|
-| [`tests/conftest.py`](../../tests/conftest.py) | работоспособная фикстура |
-| [`tests/test_config_flow.py`](../../tests/test_config_flow.py) | 🔴 **нерабочий stub** из HA template (импортирует несуществующие `CannotConnect`, `InvalidAuth`, `PlaceholderHub`) |
+| [`tests/conftest.py`](../../tests/conftest.py) | fixtures + `enable_custom_integrations` auto-applied |
+| [`tests/test_entity_migration.py`](../../tests/test_entity_migration.py) | unit-тесты `_camera_new_uid`/`_lock_new_uid` + golden vector для `lock_unique_id` |
+| [`tests/test_logging_redact.py`](../../tests/test_logging_redact.py) | unit-тесты `_logging.redact()` + `redact_path()` |
+| [`tests/test_http.py`](../../tests/test_http.py) | Bearer skip на pre-auth, no-leak между запросами, PII redact в error log |
+| [`tests/test_visibility.py`](../../tests/test_visibility.py) | hidden_by sync (first_add, USER override, un-hide, re-add) |
+| [`tests/test_visibility_real.py`](../../tests/test_visibility_real.py) | production-replica (реальные HAR-данные) + migration v2 |
+| [`pytest.ini`](../../pytest.ini) | `asyncio_mode = auto`, `testpaths = tests` |
 
 ### CI / CD
 
@@ -170,9 +175,10 @@ elektronny-gorod/
 |---|---|---|
 | [`hassfest.yaml`](../../.github/workflows/hassfest.yaml) | push / PR | manifest validation |
 | [`hacs.yaml`](../../.github/workflows/hacs.yaml) | push / PR / dispatch | HACS validation |
+| [`prerelease.yaml`](../../.github/workflows/prerelease.yaml) | PR opened / sync | pre-release ZIP с тегом `pr-N` для тестирования |
 | [`release.yaml`](../../.github/workflows/release.yaml) | release published | zip + GH release + автокоммит версии |
 
-🔴 **Отсутствует workflow для pytest.**
+🟡 **Отсутствует workflow для pytest** — все 67 тестов проходят локально (`PYTHONPATH=. pytest tests/`), но CI ещё не настроен. Tracking: roadmap → Tests-1.
 
 ## Внешние API и зависимости
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: Lead Architect Agent
-Last reviewed: 2026-05-22
+Last reviewed: 2026-05-25
 
 Source files:
 - `audit/project-audit.md` (источник find-ов)
@@ -48,20 +48,37 @@ Quality gates:
 
 **Quality gates passed:** `SECURITY_OK` (P0 cleared), `AUDIT_DONE`, `DOCS_UPDATED`.
 
-## Итерация 2 — Bronze quality scale (≈ 3-5 дней)
+## Итерация 2 — Bronze quality scale ✅ COMPLETED
 
 **Цель:** довести интеграцию до Bronze. См. [`architecture/quality-scale.md#bronze`](architecture/quality-scale.md).
 
-**Acceptance:**
-- `pytest tests/ -v` зелёный в CI;
-- `manifest.json` содержит `quality_scale: "bronze"` и `integration_type: "hub"`;
-- entity имеют `_attr_has_entity_name = True` и стабильный `unique_id`;
-- coordinator имеет `update_interval` и обновляет данные.
+**Статус:** Bronze IQS shipped. Все обязательные критерии Bronze закрыты;
+осталась одна follow-up задача — CI workflow для pytest (Tests-1).
 
-### Tasks
+**Acceptance — met:**
+- `manifest.json` содержит `quality_scale: "bronze"` и `integration_type: "hub"` ✓ (A-34);
+- entity имеют `_attr_has_entity_name = True` и стабильный `unique_id` ✓ (A-12, A-13);
+- coordinator имеет `update_interval` и обновляет данные ✓ (A-08, A-09);
+- `pytest tests/` зелёный локально (67 tests pass) ✓ — CI workflow `.github/workflows/python-tests.yaml`
+  всё ещё **не создан**, это Tests-1 follow-up (см. A-24).
 
-- [ ] **A-08** Задать `update_interval=timedelta(minutes=5)` в `ElektronnyGorodUpdateCoordinator`; в `_async_update_data` обновлять баланс + список мест; вернуть `data: dict`.
-- [ ] **A-09** Перевести Sensor / Lock / Camera на `CoordinatorEntity[ElektronnyGorodUpdateCoordinator]` + `_handle_coordinator_update`.
+### Tasks (closed)
+
+- [x] **A-08** ✅ — `update_interval=timedelta(minutes=5)` + `_async_update_data` возвращает dict.
+- [x] **A-09** ✅ — Sensor / Lock / Camera переведены на `CoordinatorEntity` + `_handle_coordinator_update`. Старые `async_update` удалены.
+- [x] **A-12** ✅ — stable `unique_id` Camera/Lock + миграция legacy через `entity_registry.async_migrate_entries`.
+- [x] **A-13** ✅ — `_attr_has_entity_name = True` + `_attr_translation_key="balance"` (sensor); Camera/Lock — имя в `device_info.name`. Раздел `entity` добавлен в `strings.json` + переводы.
+- [x] **A-14** ✅ — Sensor баланса: `device_class=MONETARY`, `state_class=TOTAL`, `unit="RUB"` (ISO 4217; константа `CURRENCY_RUBLE` удалена из `homeassistant.const` в свежих HA).
+- [x] **A-16** ✅ — `coordinator.async_unsubscribe()` зарегистрирован через `entry.async_on_unload` в `async_setup_entry`.
+- [x] **A-17** ✅ — `_collect_cameras_for_place` + `_collect_locks_for_place` helpers извлечены. (Оставшийся duplicate fan-out на per-place уровне — см. A-61.)
+- [x] **A-18** ✅ — `query_sections` удалён из coordinator.
+- [x] **A-34** ✅ — `quality_scale: "bronze"`, `integration_type: "hub"` в `manifest.json`.
+- [x] **A-44** ✅ — `async_update` камеры удалён вместе с переходом на `CoordinatorEntity` (stream URL лениво в `stream_source()`).
+- [x] **Tests baseline** ✅ — `tests/test_logging_redact.py`, `tests/test_http.py`, `tests/test_entity_migration.py`, `tests/test_visibility.py`, `tests/test_visibility_real.py` + `conftest.py` фикс + `pytest.ini`. Локально 67 tests pass.
+- [x] **PR #35 extras** ✅ — Visibility sync через `hidden_by` ↔ `/settings/screens` + one-time migration `visibility_migration_v2` (см. A-60). Bearer-omission на pre-auth endpoints (см. A-22 partial).
+
+### Tasks (deferred → Итерация 3)
+
 - [ ] **A-10** Решить `iot_class`: либо включён реальный polling — оставить `cloud_polling`; либо сменить класс. Зафиксировать в ADR-0003.
 - [x] **A-11** ✅ Поднят `hacs.json:homeassistant` до `2024.10.4` — первая stable HA с `LockState` enum, который импортирует `lock.py`. Та же версия пинится как min в CI matrix (см. python-tests.yaml).
 - [x] **A-12** ✅ slice 3c — stable `unique_id` Camera/Lock + миграция legacy через `entity_registry.async_migrate_entries`.
@@ -81,14 +98,14 @@ Quality gates:
 - [ ] **A-35** Создать `CHANGELOG.md`.
 - [ ] **A-36** Создать `CONTRIBUTING.md` со ссылкой на `aidd/contributing.md`.
 - [ ] **A-27..A-29** Поправить README (битая ссылка, `electronic_city → elektronny_gorod`, badge HA-версии).
-- [ ] **ADR-0002** «coordinator pattern: переход на CoordinatorEntity + update_interval».
-- [ ] **ADR-0004** «token redaction strategy».
+- [ ] **ADR-0002** «coordinator pattern: переход на CoordinatorEntity + update_interval» — proposed, требуется promote → accepted.
+- [ ] **ADR-0004** «token redaction strategy» — proposed, требуется promote → accepted.
 
-**Quality gates passed:** `TESTS_PASS`, `SECURITY_OK`, `REVIEW_OK`, `DOCS_UPDATED`. Integration Quality Scale: Bronze.
+**Quality gates achieved:** `SECURITY_OK`, `REVIEW_OK`, `DOCS_UPDATED`. Integration Quality Scale: **Bronze**. `TESTS_PASS` — локально зелёный, CI follow-up в Итерации 3.
 
 ## Итерация 3 — Silver + Full AIDD (≈ 5-7 дней)
 
-**Цель:** Silver Quality Scale + расширенная агентская инфраструктура.
+**Цель:** Silver Quality Scale + расширенная агентская инфраструктура + закрытие feature gaps, открытых HAR-research циклом.
 
 **Acceptance:**
 - Silver criteria по [`architecture/quality-scale.md#silver`](architecture/quality-scale.md);
@@ -99,13 +116,22 @@ Quality gates:
 
 #### HA features
 
-- [ ] **A-22** Поведение при 401: сначала собрать HAR-сессию со сценарием истечения access_token, затем реализовать **точно как в приложении** (см. [ADR-0006](decisions/0006-mirror-app-behavior.md)). До получения HAR — оставить текущее graceful поведение (UpdateFailed → пользователь делает reauth через UI).
+- [ ] **A-15** Решить судьбу `fake_timer_lock` в `lock.py` — либо удалить, либо переписать `lock` → `button`. Требует ADR-0005.
+- [ ] **A-22** (остаток) Поведение при 401: pre-auth Bearer-omission уже сделан (PR #35); осталось — собрать HAR со сценарием истечения access_token, затем реализовать `/auth/.../refresh` **точно как в приложении** (см. [ADR-0006](decisions/0006-mirror-app-behavior.md)). До получения HAR — текущее graceful поведение (UpdateFailed → reauth через UI).
 - [ ] **A-25** Native reauth flow (`async_step_reauth_confirm`).
 - [ ] **A-26** Reconfigure flow (`async_step_reconfigure`).
 - [ ] **A-37** `parallel_updates = 1` (или другое значение) на entity-классах.
 - [ ] **A-38** Обработка unavailable / log-when-unavailable.
-- [ ] **A-15** Решить судьбу `fake_timer_lock` в `lock.py` — либо удалить, либо переписать `lock` → `button`. Требует ADR-0005.
 - [ ] Repairs flow для edge-cases (заблокированный аккаунт, истёкший договор).
+
+#### Silver feature gaps (HAR-research findings)
+
+- [ ] **A-56** DND switches (3 entity per place: master + 2 dependent через `/settings/do_not_disturb`). Новая платформа `switch`.
+- [ ] **A-57** Sensor balance — extra entities из `/finance` response (binary_sensor.balance_blocked, sensor.days_to_block, sensor.next_payment_amount/date, button.pay).
+- [ ] **A-58** `/rest/v1/events/search` polling — основа для real-time event detection без STOMP/FCM. Требует **ADR-0009** (см. ниже). Закрывает основной use-case Итерации 4 более простым способом.
+- [ ] **A-59** Video retention helper — `is_within_retention(camera_type, ts)`, проверка перед video URL request. Закрывает ложные 500 для лифт/публичных камер.
+- [ ] **A-61** Двойной HTTP в per-place collectors — вынести `screens` + `access_controls` на уровень `_async_update_data`, передавать как параметры. Perf, не функциональная проблема.
+- [ ] **A-62** FAVORITES section в `_extract_hidden_ids` — расширить парсинг с учётом mixed-typed items. Fallback OK, не блокер.
 
 #### Code quality
 
@@ -135,39 +161,43 @@ Quality gates:
 
 **Quality gates passed:** `READY_FOR_RELEASE` + Silver IQS.
 
-## Итерация 4 — Real-time + push (≈ research-фаза, неопределённо)
+## Итерация 4 — Polling-based event detection (≈ 3-5 дней)
 
-**Цель:** реализовать приём событий домофона в real-time (звонок → автоматизация HA).
+**Цель:** реализовать near-real-time приём событий домофона (звонок → автоматизация HA) через polling endpoint **без** STOMP/FCM/SIP.
 
-**Принцип:** строго следуем [ADR-0006](decisions/0006-mirror-app-behavior.md) — никаких догадок без подтверждения через HAR.
+**Принцип:** строго следуем [ADR-0006](decisions/0006-mirror-app-behavior.md) — никаких догадок без подтверждения через HAR. Polling-стратегия выбрана **именно потому**, что подтверждена через HAR (`/events/search` использует само приложение); STOMP/FCM/SIP — нет.
 
-### Research-фаза (обязательна до spec)
+### Почему отказались от STOMP / FCM / SIP
 
-- [ ] **HAR-1** Собрать HAR со сценарием активного WebSocket-соединения + реальный звонок в домофон. Зафиксировать содержимое STOMP-фреймов.
-- [ ] **HAR-2** Capture SIP-трафика (через mitmproxy в TCP-mode или Wireshark) во время реального звонка. Зафиксировать INVITE / RTP flow.
-- [ ] **HAR-3** Capture поведения приложения «в фоне» (нажал home, ждал ~5 минут, входящее событие). Какие каналы реально доставляют?
-- [ ] Анализ — три канала (STOMP / SIP / FCM): что чем доставляется, какие фолбэки, какая latency.
+HAR-research цикл показал:
 
-### Возможные direction (зависят от research)
+- **STOMP**: `GET /rest/v1/stomp/available-features` для абонентов ЭГ возвращает `null` — backend feature-flag отключён. Видимо, это **платная фича Дом.ру** («Умный дом»), не включена в подписку обычных абонентов «Мой Дом». Реализация STOMP-клиента для пустого канала — пустая трата времени.
+- **FCM**: push приходят через Google Play Services, минуя HTTPS-каналы. Bridge'инг в HA требует APK реверса (FCM `project_id`, `sender_key`) → **юридически серая зона**, в scope проекта не входит.
+- **SIP**: трафик идёт вне HTTP (RTP/UDP). Полный SIP UAC в HA — серьёзный архитектурный proxy + зависимость (`pjsip`, `linphone`). Слишком жирно для базовой «звонок → автоматизация» цели.
+- **`/events/search` polling** ✅ — REST endpoint, использует то же приложение для backfill, retention 6 месяцев, page-pagination. Latency 15-30s acceptable для большинства HA-автоматизаций. Требует только cron-tick поверх существующего coordinator-паттерна.
 
-- [ ] **A-47** STOMP-клиент в `coordinator` (если WS несёт релевантные события):
-  - WebSocket subscriber поверх существующего `aiohttp` (либо `aiohttp.ClientWebSocketResponse`).
-  - SUBSCRIBE на нужные destinations (зависит от research).
-  - На приходящий MESSAGE — `async_dispatcher_send` → HA-entity / `event`.
-- [ ] **A-49** SIP-клиент (если SIP несёт INVITE для звонков):
-  - Прототип через PJSIP / Linphone CLI.
-  - Регистрация SIP UAC с credentials из `sipdevices`.
-  - На INVITE — `event` в HA + потенциально доступ к RTP audio (long-term).
-- [ ] **A-50** Camera events polling — независимая фича, не требует real-time:
-  - `GET /api/mh-camera-personal/.../cameras/{id}/events` периодически.
-  - `event` entity на каждую запись.
+### План (А-58 как основной driver)
+
+- [ ] **ADR-0009** — Polling vs STOMP/FCM для event detection. Зафиксировать **почему** отказались от других каналов. Required before code.
+- [ ] **A-58** Coordinator polls `/rest/v1/events/search?page=0` каждые 15-30 секунд (отдельный interval, **не** общий 5-минутный refresh):
+  - Dedup новых событий по `id`.
+  - `async_dispatcher_send` → HA `event` entity на каждый `accessControl` / camera.
+  - Backfill при первом setup (опционально) — до N страниц истории в HA logbook.
+  - Page-size = 20 (фикс backend), respect `last:true`.
+- [ ] **A-50** Camera events — реализовать через **тот же** `/events/search` filter по `source.type = camera` (вместо отдельного `/cameras/{id}/events` endpoint). Один polling-loop, один event-stream.
+- [ ] **ADR-0010** (опционально) — зафиксировать visibility sync strategy (`hidden_by`-based, two-way, USER override respect). Прецедент уже реализован в коде (PR #35 + A-60); ADR закрепит решение, чтобы будущие модификации не deviated.
+
+### Понижены / отложены
+
+- ~~**A-47** STOMP-клиент~~ — понижен до **P3 / skip**. Если когда-то backend включит STOMP feature flag для ЭГ абонентов — пересмотреть. Сейчас канал пуст.
+- ~~**A-49** SIP-клиент~~ — остаётся **P3 future**. Только если потребуется full intercom-call feature (RTP audio в HA) — отдельная итерация с явным spec.
 
 ### Ожидаемые исходы
 
-- Лучше всего: один STOMP-клиент закрывает 80% сценариев. Лёгкий wins для HA-автоматизаций.
-- Хуже всего: события размазаны по 3 каналам, нужны все три → сложность поддержки растёт. В этом случае — выбрать самый стабильный канал и документировать ограничения.
+- **Realistic best case**: 15-30s latency на звонок в домофон, retention 6 месяцев истории для backfill. Покрывает «90% use-cases» автоматизации «звонок → подсветить экран / уведомить».
+- **Limitation**: не real-time (latency, не sub-second). Если пользователю нужна моментальная реакция — это **out of scope без STOMP/SIP**, документировать в README.
 
-**Quality gates passed:** READY_FOR_RELEASE + Silver IQS + работающая push-фича.
+**Quality gates passed:** `READY_FOR_RELEASE` + Silver IQS + polling-based event entity работает.
 
 ## Принципы
 
@@ -206,6 +236,11 @@ Tests
 | 0003 | Стратегия `iot_class` и polling | начало Итерации 2 |
 | 0004 | Token redaction strategy | начало Итерации 1 (post-factum для уже сделанных правок) |
 | 0005 | Lock vs Button для домофона | Итерация 3 |
+| 0006 | Mirror application behavior | accepted |
+| 0007 | Stateful emulator baseline | accepted |
+| 0008 | Shared aiohttp ClientSession | Итерация 2 |
+| 0009 | Polling vs STOMP/FCM для event detection | **required** перед A-58 (Итерация 4) |
+| 0010 | Visibility sync strategy (hidden_by, two-way) | опц., Итерация 3-4 (post-factum для PR #35) |
 
 ## Risks
 


### PR DESCRIPTION
## Summary

Docs-only PR. Sync `audit/project-audit.md`, `roadmap.md` и `project/project-map.md` с фактическим состоянием master после релиза 3.1.0 (PR #35).

## Audit changes (audit/project-audit.md)

**Closed** (status updated):
- A-07 — tests baseline shipped (67 pass).
- A-17, A-18 — coordinator refactor (slice 3a).

**Partial** (status уточнён):
- A-22 — Bearer не блокирует /auth/* (готово); native reauth screen — остаётся в A-25.

**Added 7 new findings** из research-цикла + PR #35:
| ID | Description | Priority |
|---|---|---|
| A-56 | DND switches (3 entity per place) | P2 Silver |
| A-57 | Sensor balance — extra attrs из /finance | P2 Silver |
| A-58 | /events/search polling — основа event detection | P1 Silver |
| A-59 | Video retention по типу камеры (14d intercom / 7d public) | P3 UX |
| A-60 | Visibility migration v2 — RESOLVED (code shipped) | - |
| A-61 | Двойной HTTP в _collect_locks_for_place | P3 perf |
| A-62 | FAVORITES section в _extract_hidden_ids | P3 correctness |

## Roadmap changes (roadmap.md)

- **Итерация 2** — ✅ COMPLETED (Bronze IQS released 3.1.0). Tests-1 (CI workflow .github/workflows/python-tests.yaml) — follow-up.
- **Итерация 3** — добавлен подраздел Silver feature gaps (A-56..A-62).
- **Итерация 4 переписана** — driver сменился со STOMP/FCM на polling /events/search (A-58). Раздел «Почему отказались от STOMP/FCM/SIP» объясняет три отдельные причины (STOMP feature flag отключён для абонентов ЭГ, FCM требует APK реверса, SIP вне HTTP). A-47 (STOMP) → P3/skip. ADR-0009 (polling vs STOMP/FCM) — required before A-58 implementation.

## Project-map changes (project-map.md)

Sync stale descriptions после рефакторингов 3.0.5→3.1.0:
- coordinator.py: «без update_interval» → «update_interval=5min, returns dict» (ADR-0002).
- http.py: «per-request ClientSession()» → «shared session + per-request headers + Bearer skip /auth/* + redact_path()» (ADR-0008 + PR #35).
- camera/lock/sensor.py: добавлены stable unique_id + CoordinatorEntity + (sensor) long-term statistics.
- Tests-таблица: stub `test_config_flow.py` (удалён) → 5 реальных тестовых файлов.
- CI/CD: добавлен prerelease.yaml. Pytest CI warning → 🟡 (локально работает).

## Test plan

- [x] Docs-only PR — никаких code changes.
- [x] grep на consistency: A-NN references, ADR references — все валидны.
- [ ] После merge: создать ADR-0009 (polling-based event detection) отдельным PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)