### PR TITLE
perf(coordinator): A-61 — убрать двойной HTTP в per-place collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Coordinator: убран двойной HTTP в per-place collectors** ([A-61](docs/audit/project-audit.md)). `_collect_locks_for_place` ранее дублировал `query_screens_settings` + `query_access_controls`, уже вызванные `_collect_cameras_for_place`. Теперь pre-fetch в `_async_update_data` (один раз per place), передача в оба collectors как параметры. **Экономия: -2 HTTP per place per 5min refresh** (-576 calls/day для 1 place). Поведение неизменно — 74 tests pass (+3 new regression-guard). NOTE: при ошибке `query_access_controls` теперь и cameras, и locks для того места пусты (раньше locks могли survive независимо — теперь это атомарная per-place операция).
+
 ### Added
 
 - **Do Not Disturb switches** ([A-56](docs/audit/project-audit.md)). Для каждого place добавлены 3 switch entity (mirror приложения «Мой Дом» → Настройки → Уведомления → Не беспокоить):

--- a/custom_components/elektronny_gorod/coordinator.py
+++ b/custom_components/elektronny_gorod/coordinator.py
@@ -167,13 +167,37 @@ class ElektronnyGorodUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if balance:
                     balances.append(balance)
 
+            # Pre-fetch shared per-place data (A-61): screens + access_controls
+            # нужны и для cameras (для hidden), и для locks. Раньше каждый
+            # collector делал свой fetch — двойной HTTP. Теперь один раз per
+            # place, передаём в collectors как параметры.
             try:
-                cameras.extend(await self._collect_cameras_for_place(place_id))
+                screens = await self._api.query_screens_settings(place_id)
+            except Exception as ex:  # noqa: BLE001
+                LOGGER.warning("Screens fetch failed for place_id=%s: %s", place_id, ex)
+                screens = {}
+            try:
+                access_controls = await self._api.query_access_controls(place_id)
+            except Exception as ex:  # noqa: BLE001
+                LOGGER.warning(
+                    "Access controls fetch failed for place_id=%s: %s", place_id, ex
+                )
+                access_controls = []
+
+            hidden_cam_ids = self._extract_hidden_ids(screens, "PUBLIC_CAMERAS")
+            hidden_entrance_ids = self._extract_hidden_ids(screens, "ACCESS_CONTROLS")
+
+            try:
+                cameras.extend(await self._collect_cameras_for_place(
+                    place_id, access_controls, hidden_cam_ids, hidden_entrance_ids
+                ))
             except Exception as ex:  # noqa: BLE001
                 LOGGER.warning("Cameras fetch failed for place_id=%s: %s", place_id, ex)
 
             try:
-                locks.extend(await self._collect_locks_for_place(place_id))
+                locks.extend(self._collect_locks_for_place(
+                    place_id, access_controls, hidden_entrance_ids
+                ))
             except Exception as ex:  # noqa: BLE001
                 LOGGER.warning("Locks fetch failed for place_id=%s: %s", place_id, ex)
 
@@ -234,8 +258,23 @@ class ElektronnyGorodUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "company": finance.get("company"),
         }
 
-    async def _collect_cameras_for_place(self, place_id: str) -> list[dict[str, Any]]:
+    async def _collect_cameras_for_place(
+        self,
+        place_id: str,
+        access_controls: list[dict[str, Any]],
+        hidden_cam_ids: set[str],
+        hidden_entrance_ids: set[str],
+    ) -> list[dict[str, Any]]:
         """Камеры одного place — три источника (access_controls + public + cameras).
+
+        Args:
+            place_id: ID места.
+            access_controls: pre-fetched access controls (общий результат с
+                _collect_locks_for_place; раньше каждый делал свой запрос —
+                A-61).
+            hidden_cam_ids: pre-extracted из `/settings/screens` PUBLIC_CAMERAS
+                раздел (общий с locks для ACCESS_CONTROLS hidden — A-61).
+            hidden_entrance_ids: pre-extracted из ACCESS_CONTROLS раздел.
 
         ⚠️ **Структура API** (см. api-reference §Access controls):
         `externalCameraId` существует на ДВУХ уровнях:
@@ -261,20 +300,10 @@ class ElektronnyGorodUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         cameras: list[dict[str, Any]] = []
 
-        # screens settings — для уважения user app preferences (visibility).
-        try:
-            screens = await self._api.query_screens_settings(place_id)
-        except Exception as ex:  # noqa: BLE001
-            LOGGER.warning("Screens settings failed for place_id=%s: %s", place_id, ex)
-            screens = {}
-        hidden_cam_ids = self._extract_hidden_ids(screens, "PUBLIC_CAMERAS")
-        hidden_entrance_ids = self._extract_hidden_ids(screens, "ACCESS_CONTROLS")
-
         # 1. Access controls (домофоны).
         # hidden для intercom-камеры берётся из ACCESS_CONTROLS.hidden — если
         # user скрыл entrance в приложении, и lock и camera этого entrance
         # получат `enabled_default=False`.
-        access_controls = await self._api.query_access_controls(place_id)
         for ac in access_controls:
             ac_id = ac.get("id")
             entrances = ac.get("entrances") or []
@@ -352,8 +381,21 @@ class ElektronnyGorodUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     result.add(str(iid))
         return result
 
-    async def _collect_locks_for_place(self, place_id: str) -> list[dict[str, Any]]:
+    def _collect_locks_for_place(
+        self,
+        place_id: str,
+        access_controls: list[dict[str, Any]],
+        hidden_entrance_ids: set[str],
+    ) -> list[dict[str, Any]]:
         """Locks одного place (один per entrance, либо per AC если без entrances).
+
+        Args:
+            place_id: ID места.
+            access_controls: pre-fetched (общий результат с
+                _collect_cameras_for_place; раньше каждый делал свой запрос —
+                A-61).
+            hidden_entrance_ids: pre-extracted из `/settings/screens`
+                ACCESS_CONTROLS раздел.
 
         `name` — entrance.name (для UI entity, чтобы различать "Подъезд 1" /
         "Калитка 2"). `ac_name` — имя access_control (физического домофона),
@@ -362,15 +404,6 @@ class ElektronnyGorodUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         (user в приложении скрыл entrance) → entity получит enabled_default=False.
         """
         locks: list[dict[str, Any]] = []
-        # screens для hidden — повторный вызов после _collect_cameras_for_place;
-        # это +1 HTTP per place per refresh. TODO: вынести screens на верхний
-        # уровень `_async_update_data` чтобы запросить один раз.
-        try:
-            screens = await self._api.query_screens_settings(place_id)
-        except Exception:  # noqa: BLE001
-            screens = {}
-        hidden_entrance_ids = self._extract_hidden_ids(screens, "ACCESS_CONTROLS")
-        access_controls = await self._api.query_access_controls(place_id)
         for ac in access_controls:
             ac_name = ac.get("name")
             entrances = ac.get("entrances") or []

--- a/docs/audit/project-audit.md
+++ b/docs/audit/project-audit.md
@@ -488,21 +488,16 @@ Quality gates:
 
 ### A-61. Двойной HTTP в per-place collectors
 
-- **Severity:** P3 (perf, не функциональная проблема).
-- **Area:** Performance.
-- **Evidence:** [`coordinator.py:_collect_locks_for_place`](../../custom_components/elektronny_gorod/coordinator.py)
-  повторно вызывает `query_screens_settings` и `query_access_controls`,
-  которые уже были fetched в `_collect_cameras_for_place` для того же
-  place. В самом коде есть TODO-комментарий: «это +1 HTTP per place per
-  refresh. TODO: вынести screens на верхний уровень».
-- **Impact:** +2 HTTP per place per refresh (screens + access_controls).
-  При 5-минутном update_interval и N places — 2N лишних requests
-  каждые 5 минут. Это **не** функциональная проблема (данные одинаковые,
-  results корректные), а излишняя нагрузка на оператора + лишний latency.
-- **Recommended fix:** в `_async_update_data` для каждого place fetch
-  screens + access_controls один раз → передавать в `_collect_cameras_for_place`
-  и `_collect_locks_for_place` как параметры (вместо повторного fetch
-  внутри). От code-reviewer hand-off.
+- **Status:** ✅ **RESOLVED** в branch `feat/a61-fix-double-http` (PR TBD).
+  Pre-fetch `screens` + `access_controls` в `_async_update_data` per place,
+  передача в оба collectors как параметры. `_collect_cameras_for_place`
+  signature расширена до 4 параметров. `_collect_locks_for_place` теперь
+  pure-sync (нет awaitов). **Экономия: -2 HTTP per place per 5min refresh**
+  (-576 calls/day для 1 place, scales linearly). 3 new unit-теста (TDD
+  strict — RED first → GREEN после refactor). Behavioral NOTE: при ошибке
+  `query_access_controls` теперь и cameras, и locks пусты для того place
+  (раньше locks могли survive независимо — теперь per-place операция
+  атомарна). См. CHANGELOG.
 
 ### A-62. FAVORITES section в `/settings/screens` не парсится
 
@@ -536,7 +531,7 @@ Quality gates:
 | A-08..A-14, A-16..A-21, A-23, A-24, A-44, A-55 | Итерация 2 (Bronze IQS — shipped в 3.1.0) |
 | A-60 | Итерация 2 (visibility migration v2 — shipped в 3.1.0) |
 | A-15, A-22 (остаток), A-25, A-26, A-37, A-38, A-48, A-51, A-52 | Итерация 3 |
-| ✅ A-56 + ✅ A-57 (shipped 3.2.0 TBD), A-58, A-59, A-61, A-62 | Итерация 3 (Silver feature gaps) |
+| ✅ A-56 + ✅ A-57 + ✅ A-61 (shipped 3.2.0 TBD), A-58, A-59, A-62 | Итерация 3 (Silver feature gaps) |
 | A-58 (research pending), A-47 (P3/skip), A-49 (P3 future), A-50 | Итерация 4 (real-time event detection — research-фаза, ADR-0009 после R-1..R-5) |
 | A-27..A-36, A-39..A-41, A-53, A-54 | по мере touch / документирование |
 | A-42, A-46 | информация (не задача) |

--- a/tests/test_coordinator_no_double_http.py
+++ b/tests/test_coordinator_no_double_http.py
@@ -1,0 +1,165 @@
+"""Tests for A-61: `_collect_locks_for_place` не должен дублировать
+`query_screens_settings` + `query_access_controls`.
+
+Раньше:
+- `_collect_cameras_for_place(place_id)` вызывал screens + access_controls.
+- `_collect_locks_for_place(place_id)` вызывал screens + access_controls
+  снова (+2 HTTP per place per refresh).
+
+После A-61:
+- Pre-fetch screens + access_controls в `_async_update_data` (один раз
+  per place), передать в оба collectors как параметры.
+
+Acceptance: 1 call для каждого endpoint per place. Поведение неизменно
+(тесты A-57 / DND / visibility всё ещё pass).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.elektronny_gorod.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_OPERATOR_ID,
+    CONF_REFRESH_TOKEN,
+    CONF_USER_AGENT,
+    DOMAIN,
+)
+from custom_components.elektronny_gorod.user_agent import UserAgent
+
+
+@pytest.fixture
+def mock_api_counted():
+    """Mock с реальным AsyncMock — call_count проверим напрямую."""
+    with patch(
+        "custom_components.elektronny_gorod.coordinator.ElektronnyGorodAPI"
+    ) as mock_cls:
+        instance = mock_cls.return_value
+        instance.http = AsyncMock()
+        instance.http.user_agent = AsyncMock()
+        instance.query_places = AsyncMock(return_value=[{
+            "subscriber": {"id": "S1", "accountId": "A1", "name": "Test"},
+            "place": {"id": "P1", "address": "addr"},
+        }])
+        instance.query_balance = AsyncMock(return_value={})
+        # Access controls: 1 AC с 1 entrance — чтобы locks builder отработал.
+        instance.query_access_controls = AsyncMock(return_value=[
+            {
+                "id": "AC1",
+                "name": "Door",
+                "entrances": [
+                    {
+                        "id": "E1",
+                        "externalCameraId": 100,
+                        "name": "Подъезд 1",
+                        "allowOpen": True,
+                    }
+                ],
+            }
+        ])
+        instance.query_cameras = AsyncMock(return_value=[])
+        instance.query_public_cameras = AsyncMock(return_value=[
+            {"id": 200, "externalCameraId": None, "name": "City cam"}
+        ])
+        instance.query_screens_settings = AsyncMock(return_value={
+            "screens": [
+                {"type": "ACCESS_CONTROLS", "entities": [], "hidden": []},
+                {"type": "PUBLIC_CAMERAS", "entities": [], "hidden": []},
+            ]
+        })
+        instance.query_dnd_settings = AsyncMock(return_value=[])
+        yield mock_cls
+
+
+def _make_config_entry() -> MockConfigEntry:
+    ua = UserAgent()
+    ua.operator_id = "1"
+    return MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        unique_id="test_unique_subscriber_S1",
+        title="Test",
+        data={
+            CONF_ACCESS_TOKEN: "T1",
+            CONF_REFRESH_TOKEN: "R1",
+            CONF_OPERATOR_ID: "1",
+            CONF_USER_AGENT: json.dumps(ua.json()),
+            "account_id": "A1",
+            "subscriber_id": "S1",
+            "use_go2rtc": False,
+            "go2rtc_base_url": "http://127.0.0.1:1984",
+            "go2rtc_rtsp_host": "127.0.0.1",
+        },
+    )
+
+
+async def test_query_screens_settings_called_once_per_refresh(
+    hass: HomeAssistant, mock_api_counted
+):
+    """A-61: screens settings вызывается 1 раз per place per refresh (раньше
+    было 2 — дубликат из _collect_locks_for_place).
+
+    Сравниваем с `query_places` (тоже 1 per refresh) — refactor success если
+    отношение 1:1, независимо от количества refresh-циклов HA сделал на setup.
+    """
+    entry = _make_config_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    instance = mock_api_counted.return_value
+    refresh_count = instance.query_places.await_count
+    assert instance.query_screens_settings.await_count == refresh_count, (
+        f"screens settings должен быть == refresh_count={refresh_count} "
+        f"(один раз per place per refresh), got {instance.query_screens_settings.await_count}"
+    )
+
+
+async def test_query_access_controls_called_once_per_refresh(
+    hass: HomeAssistant, mock_api_counted
+):
+    """A-61: access_controls тоже не дублируется (cameras + locks delят один
+    результат, ratio 1:1 c query_places)."""
+    entry = _make_config_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    instance = mock_api_counted.return_value
+    refresh_count = instance.query_places.await_count
+    assert instance.query_access_controls.await_count == refresh_count, (
+        f"access_controls должен быть == refresh_count={refresh_count} "
+        f"(один раз per place per refresh), got {instance.query_access_controls.await_count}"
+    )
+
+
+async def test_data_still_correct_after_dedup(
+    hass: HomeAssistant, mock_api_counted
+):
+    """Sanity: после dedup HTTP coordinator.data всё ещё содержит правильные
+    cameras + locks (refactor не сломал бизнес-логику)."""
+    entry = _make_config_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    data = coordinator.data
+
+    # 1 intercom camera (от entrance.externalCameraId=100) + 1 public.
+    assert len(data["cameras"]) == 2, (
+        f"Expected 2 cameras (1 intercom + 1 public), got {len(data['cameras'])}"
+    )
+    # 1 lock (один entrance).
+    assert len(data["locks"]) == 1, f"Expected 1 lock, got {len(data['locks'])}"
+    lock = data["locks"][0]
+    assert lock["place_id"] == "P1"
+    assert lock["access_control_id"] == "AC1"
+    assert lock["entrance_id"] == "E1"
+    assert lock["name"] == "Подъезд 1"


### PR DESCRIPTION
## Summary

A-61 (P3 perf): убрать дублирующиеся `query_screens_settings` + `query_access_controls` в `_collect_locks_for_place` — они уже вызывались в `_collect_cameras_for_place`.

**Экономия**: -2 HTTP per place per 5min refresh = **-576 calls/day** для 1 place, scales linearly.

Closes [A-61](docs/audit/project-audit.md).

## Архитектура

| | Было | Стало |
|---|---|---|
| `_async_update_data` per place | balance → cameras → locks → dnd | balance → **screens+access_controls (pre-fetch)** → cameras → locks → dnd |
| `_collect_cameras_for_place` | `async def(place_id)` | `async def(place_id, access_controls, hidden_cam_ids, hidden_entrance_ids)` |
| `_collect_locks_for_place` | `async def(place_id)` (с awaitами на дубликаты) | `def(place_id, access_controls, hidden_entrance_ids)` (pure-sync) |

## TDD strict

3 теста created first:
- `test_query_screens_settings_called_once_per_refresh` (RED: 2:1, GREEN после: 1:1)
- `test_query_access_controls_called_once_per_refresh` (то же)
- `test_data_still_correct_after_dedup` (sanity, GREEN с самого начала)

After refactor → 74/74 full suite pass.

## Pre-PR checklist

- [x] **TDD strict**: tests first.
- [x] **code-review-and-quality**: subagent approve with minor, fix applied (docstring cleanup).
- [x] **documentation-and-adrs**: CHANGELOG `[Unreleased]` Changed section + behavioral NOTE, audit A-61 → ✅ RESOLVED, priority table updated.
- [x] **Tests pass**: 74/74.

## Behavioral NOTE (важно для review)

При ошибке `query_access_controls` теперь **и** cameras, **и** locks пусты для того place. Раньше locks могли survive независимо (свой fetch внутри collector). Теперь per-place операция атомарна. Acceptable для shared endpoint при 5-минутном refresh — partial recovery не имеет smysla когда backend down.

## Breaking change

Нет (internal refactor, signatures private методов).

🤖 Generated with [Claude Code](https://claude.com/claude-code)