### PR TITLE
fix(camera): A-63 — skip stream/snapshot для hidden cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Camera: skip stream/snapshot fetch для hidden cameras** ([A-63](docs/audit/project-audit.md)). HA core и downstream-интеграции (frigate, webrtc preview, advanced lovelace) могут вызывать `stream_source()` и `async_camera_image()` для всех зарегистрированных camera entities — включая скрытые в HA UI (`hidden_by` любого reason: `INTEGRATION` от visibility sync на основе `/settings/screens`, `USER` если юзер выключил «Показывать на панели»). Раньше это приводило к лишним HTTP-запросам к operator API для камер, которых юзер не видит (production-лог 2026-05-26: `Camera init id=... hidden=True` → `Fetching camera ... stream URL`). Теперь helper `_is_hidden()` skip-нет вызов БЕЗ обращения к coordinator если `registry_entry.hidden_by is not None`. Чтобы вернуть видео — toggle «Показывать на панели» в entity-edit page (HA устанавливает `hidden_by=None`). 5 regression-тестов (`tests/test_camera_hidden_skip.py`). Visible cameras работают без изменений. **NOTE**: наш sync пока overrides user «Показать» на следующем 5-min refresh — отдельный follow-up.
+
 ### Changed
 
 - **Coordinator: убран двойной HTTP в per-place collectors** ([A-61](docs/audit/project-audit.md)). `_collect_locks_for_place` ранее дублировал `query_screens_settings` + `query_access_controls`, уже вызванные `_collect_cameras_for_place`. Теперь pre-fetch в `_async_update_data` (один раз per place), передача в оба collectors как параметры. **Экономия: -2 HTTP per place per 5min refresh** (-576 calls/day для 1 place). Поведение неизменно — 74 tests pass (+3 new regression-guard). NOTE: при ошибке `query_access_controls` теперь и cameras, и locks для того места пусты (раньше locks могли survive независимо — теперь это атомарная per-place операция).

--- a/custom_components/elektronny_gorod/camera.py
+++ b/custom_components/elektronny_gorod/camera.py
@@ -261,11 +261,30 @@ class ElektronnyGorodCamera(
     # On-demand actions                                                  #
     # ------------------------------------------------------------------ #
 
+    def _is_hidden(self) -> bool:
+        """A-63: skip stream/snapshot fetch если entity не показывается в UI.
+
+        Skip когда `registry_entry.hidden_by is not None` — любой reason:
+        - INTEGRATION: наш `_sync_visibility` пометил на основе API hidden=True;
+        - USER: юзер выключил «Показывать на панели» через HA UI;
+        - DEVICE: каскад от device-level (не используем сейчас).
+
+        Любой hidden = юзер не видит camera card в UI = HTTP/stream бесполезен.
+        Чтобы включить обратно — toggle «Показывать на панели» в entity-edit
+        page (HA устанавливает `hidden_by=None`).
+
+        `registry_entry` is None в окне между `__init__` и `async_added_to_hass` —
+        safe default «не скрыто» (этот код всё равно вызывается уже после
+        async_added_to_hass, но guard на всякий случай).
+        """
+        reg = self.registry_entry
+        return reg is not None and reg.hidden_by is not None
+
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return bytes of camera image."""
-        if not self.available:
+        if self._is_hidden() or not self.available:
             return None
         image = await self.coordinator.get_camera_snapshot(self._id, width, height)
         if image:
@@ -274,6 +293,8 @@ class ElektronnyGorodCamera(
 
     async def stream_source(self) -> str | None:
         """Return the source of the stream."""
+        if self._is_hidden():
+            return None
         stream_url = await self.coordinator.get_camera_stream(self._id)
         if not stream_url:
             LOGGER.warning("Camera %s (%s): empty source stream url", self._name, self._id)

--- a/docs/audit/project-audit.md
+++ b/docs/audit/project-audit.md
@@ -527,26 +527,37 @@ Quality gates:
 
 ### A-63. HA prefetches `stream_source()` для hidden cameras
 
-- **Severity:** P2 (perf — лишние HTTP, +UX noise).
-- **Area:** HA-compat / Performance.
-- **Evidence:** в логе зафиксированы повторяющиеся `Fetching camera <id> stream URL`
-  для camera_id с `hidden=True` (например `Camera init id=5593586 ... hidden=True`,
-  затем `Fetching camera 5593586 stream URL`). Hidden cameras всё равно
-  зарегистрированы как entities (`hidden_by=INTEGRATION` — state machine
-  работает), и HA core/integrations (frigate, webrtc preview, advanced lovelace)
-  могут вызывать `stream_source()` для всех зарегистрированных camera entities.
-- **Impact:** лишний HTTP-запрос (`/api/.../intercoms/{id}` или public-camera
-  endpoint) на каждую hidden camera. На квартире с 15 hidden public cams —
-  это +15 HTTP per stream-trigger event. Под нагрузкой frigate/webrtc/...
-  даёт ощутимый рост трафика без полезного результата.
-- **Recommended fix:** в [`camera.py:stream_source`](../../custom_components/elektronny_gorod/camera.py#L275)
-  ранний return `None` если `self.registry_entry.hidden_by is not None` (или
-  если `coordinator_camera_info["hidden"] is True`). Hidden камера не должна
-  fetch live stream — у юзера её даже нет в UI. Аналогично для
-  `async_camera_image` (snapshot prefetch).
-- **Test plan:** unit-тест — `stream_source()` возвращает None если entity
-  hidden, и не дёргает `coordinator.get_camera_stream`. Mock coordinator
-  call_count == 0 для hidden.
+- **Status:** ✅ **RESOLVED** в branch `fix/a63-skip-hidden-stream-source` (PR TBD).
+  Helper `camera.py:_is_hidden` проверяет `registry_entry.hidden_by is not None`
+  (любой reason — INTEGRATION/USER/DEVICE). `stream_source()` и
+  `async_camera_image()` возвращают `None` БЕЗ обращения к
+  `coordinator.get_camera_stream` / `get_camera_snapshot`.
+
+  **Логика:** hidden_by = entity не показывается в UI юзеру = HTTP/stream
+  бесполезен. Чтобы включить обратно — toggle «Показывать на панели» в
+  entity-edit page (HA устанавливает `hidden_by=None`).
+
+  **Дизайн-эволюция fix (через 3 итерации фидбэка)**:
+  1. **v1**: skip любой `hidden_by != None`. Юзер обнаружил: «нашёл скрытую
+     камеру в Settings → Entities, ожидаю видео — а нет».
+  2. **v2 (narrow)**: skip только `INTEGRATION + API hidden`. USER-hidden
+     stream работает. Юзер обнаружил: «выключил Показывать на панели,
+     stream всё равно тянется — почему?»
+  3. **v3 (final)**: skip любой `hidden_by != None`. Юзер может через
+     toggle «Показывать на панели» (`hidden_by=None`) включить видео.
+
+  5 unit-тестов (`tests/test_camera_hidden_skip.py`):
+  visible / INTEGRATION-hidden / snapshot variant / USER-hidden /
+  user-override show. См. CHANGELOG.
+- **Original Severity:** P2 (perf — лишние HTTP, +UX noise).
+- **Original Evidence:** в production-логе 2026-05-26 повторяющиеся
+  `Fetching camera <id> stream URL` для camera_id с `hidden=True`. На
+  квартире с 15 hidden public cams — +15 HTTP per stream-trigger event
+  от frigate/webrtc preview.
+- **Known follow-up:** наш `_sync_visibility` сейчас **overrides** user
+  «Показать» на следующем 5-минутном refresh (ставит INTEGRATION обратно).
+  Это отдельная UX-проблема — track как отдельный finding или включить в
+  A-64 scope (sync_visibility semantics rewrite).
 
 ### A-64. `_sync_visibility` / migration → reload cascade
 

--- a/tests/test_camera_hidden_skip.py
+++ b/tests/test_camera_hidden_skip.py
@@ -1,0 +1,300 @@
+"""Tests for A-63: skip stream/snapshot если entity скрыта в HA UI.
+
+Контекст:
+- HA core + downstream-интеграции (frigate, webrtc preview, advanced
+  lovelace) могут вызывать `stream_source()` для всех зарегистрированных
+  camera entities — включая те, что `hidden_by != None`.
+- Hidden камера в UI юзеру не видна → fetcher live stream бесполезен.
+- Production-лог 2026-05-26 показал такие prefetch.
+
+Skip когда `registry_entry.hidden_by is not None` (любой reason):
+- INTEGRATION: наш `_sync_visibility` пометил на основе API hidden=True;
+- USER: юзер выключил «Показывать на панели» через HA UI;
+- DEVICE: каскад от device-level (не используем сейчас).
+
+Юзер может easily включить обратно — toggle «Показывать на панели» в
+entity-edit page (HA устанавливает `hidden_by=None`).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.elektronny_gorod.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_OPERATOR_ID,
+    CONF_REFRESH_TOKEN,
+    CONF_USER_AGENT,
+    DOMAIN,
+)
+from custom_components.elektronny_gorod.user_agent import UserAgent
+
+VISIBLE_CAMERA_ID = "111"
+HIDDEN_CAMERA_ID = "222"
+PLACE_ID = "P1"
+
+
+def _screens_with_hidden() -> dict[str, Any]:
+    return {
+        "screens": [
+            {
+                "type": "PUBLIC_CAMERAS",
+                "entities": [
+                    {"id": int(VISIBLE_CAMERA_ID), "type": "PUBLIC_CAMERA", "order": 0},
+                ],
+                "hidden": [
+                    {"id": int(HIDDEN_CAMERA_ID), "type": "PUBLIC_CAMERA"},
+                ],
+            },
+            {"type": "ACCESS_CONTROLS", "entities": [], "hidden": []},
+        ]
+    }
+
+
+def _places() -> list[dict[str, Any]]:
+    return [
+        {
+            "subscriber": {"id": "S1", "accountId": "A1", "name": "Test"},
+            "place": {"id": PLACE_ID, "address": "addr"},
+        }
+    ]
+
+
+def _public_cameras() -> list[dict[str, Any]]:
+    return [
+        {"id": int(VISIBLE_CAMERA_ID), "externalCameraId": None, "name": "Двор"},
+        {"id": int(HIDDEN_CAMERA_ID), "externalCameraId": None, "name": "Скрытая"},
+    ]
+
+
+@pytest.fixture
+def mock_api_with_streams():
+    """API mock + AsyncMock на get_camera_stream/snapshot — будем проверять call_count."""
+    with patch(
+        "custom_components.elektronny_gorod.coordinator.ElektronnyGorodAPI"
+    ) as mock_cls:
+        instance = mock_cls.return_value
+        instance.http = AsyncMock()
+        instance.http.user_agent = AsyncMock()
+        instance.query_places = AsyncMock(return_value=_places())
+        instance.query_balance = AsyncMock(return_value={})
+        instance.query_access_controls = AsyncMock(return_value=[])
+        instance.query_cameras = AsyncMock(return_value=[])
+        instance.query_public_cameras = AsyncMock(return_value=_public_cameras())
+        instance.query_screens_settings = AsyncMock(return_value=_screens_with_hidden())
+        instance.query_dnd_settings = AsyncMock(return_value=[])
+        # Эти два — реальная цель проверки.
+        instance.query_camera_stream = AsyncMock(return_value="https://example/stream.flv")
+        instance.query_camera_snapshot = AsyncMock(return_value=b"\x89PNG\r\n")
+        yield mock_cls
+
+
+def _make_config_entry() -> MockConfigEntry:
+    ua = UserAgent()
+    ua.operator_id = "1"
+    return MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        unique_id="test_unique_subscriber_S1",
+        title="Test",
+        data={
+            CONF_ACCESS_TOKEN: "T1",
+            CONF_REFRESH_TOKEN: "R1",
+            CONF_OPERATOR_ID: "1",
+            CONF_USER_AGENT: json.dumps(ua.json()),
+            "account_id": "A1",
+            "subscriber_id": "S1",
+            "use_go2rtc": False,
+            "go2rtc_base_url": "http://127.0.0.1:1984",
+            "go2rtc_rtsp_host": "127.0.0.1",
+        },
+    )
+
+
+def _get_camera_entity(hass: HomeAssistant, unique_id: str):
+    """Возвращает camera entity instance из platform component."""
+    from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
+
+    component = hass.data.get(CAMERA_DOMAIN)
+    if component is None:
+        return None
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("camera", DOMAIN, unique_id)
+    if entity_id is None:
+        return None
+    return component.get_entity(entity_id)
+
+
+# ─── Test A: hidden camera — stream_source returns None, no API call ─────────
+
+
+async def test_stream_source_returns_none_for_hidden_camera(
+    hass: HomeAssistant, mock_api_with_streams
+):
+    """A-63: hidden_by=INTEGRATION → stream_source() возвращает None
+    БЕЗ вызова coordinator.get_camera_stream → API."""
+    entry = _make_config_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    instance = mock_api_with_streams.return_value
+    instance.query_camera_stream.reset_mock()
+
+    hidden_camera = _get_camera_entity(
+        hass, f"{DOMAIN}_camera_{HIDDEN_CAMERA_ID}"
+    )
+    assert hidden_camera is not None, "hidden camera entity должна существовать (state machine работает)"
+
+    # Sanity: registry_entry правда hidden_by=INTEGRATION (precondition).
+    registry = er.async_get(hass)
+    reg_entry = registry.async_get(hidden_camera.entity_id)
+    assert reg_entry.hidden_by == er.RegistryEntryHider.INTEGRATION, (
+        f"precondition: hidden camera должна иметь hidden_by=INTEGRATION, "
+        f"got {reg_entry.hidden_by!r}"
+    )
+
+    result = await hidden_camera.stream_source()
+    assert result is None, f"stream_source() для hidden должен вернуть None, got {result!r}"
+    assert instance.query_camera_stream.await_count == 0, (
+        f"query_camera_stream НЕ должен вызываться для hidden camera, "
+        f"got call_count={instance.query_camera_stream.await_count}"
+    )
+
+
+# ─── Test B: visible camera — поведение не меняется ──────────────────────────
+
+
+async def test_stream_source_visible_camera_still_works(
+    hass: HomeAssistant, mock_api_with_streams
+):
+    """Regression: visible camera (hidden_by=None) всё ещё получает stream URL."""
+    entry = _make_config_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    instance = mock_api_with_streams.return_value
+    instance.query_camera_stream.reset_mock()
+
+    visible_camera = _get_camera_entity(
+        hass, f"{DOMAIN}_camera_{VISIBLE_CAMERA_ID}"
+    )
+    assert visible_camera is not None
+
+    registry = er.async_get(hass)
+    reg_entry = registry.async_get(visible_camera.entity_id)
+    assert reg_entry.hidden_by is None, (
+        f"precondition: visible camera hidden_by должен быть None, "
+        f"got {reg_entry.hidden_by!r}"
+    )
+
+    result = await visible_camera.stream_source()
+    assert result == "https://example/stream.flv", (
+        f"visible camera stream_source должен вернуть URL, got {result!r}"
+    )
+    assert instance.query_camera_stream.await_count == 1
+
+
+# ─── Test C: hidden camera — snapshot тоже skip ──────────────────────────────
+
+
+async def test_async_camera_image_returns_none_for_hidden_camera(
+    hass: HomeAssistant, mock_api_with_streams
+):
+    """A-63: hidden_by=INTEGRATION → async_camera_image() тоже возвращает None
+    БЕЗ вызова coordinator.get_camera_snapshot → API."""
+    entry = _make_config_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    instance = mock_api_with_streams.return_value
+    instance.query_camera_snapshot.reset_mock()
+
+    hidden_camera = _get_camera_entity(
+        hass, f"{DOMAIN}_camera_{HIDDEN_CAMERA_ID}"
+    )
+    assert hidden_camera is not None
+
+    result = await hidden_camera.async_camera_image()
+    assert result is None, f"async_camera_image() для hidden должен вернуть None, got {result!r}"
+    assert instance.query_camera_snapshot.await_count == 0, (
+        f"query_camera_snapshot НЕ должен вызываться для hidden camera, "
+        f"got call_count={instance.query_camera_snapshot.await_count}"
+    )
+
+
+# ─── Test D: USER-hidden — skip (юзер отключил «Показывать на панели») ──────
+
+
+async def test_stream_source_returns_none_for_user_hidden_camera(
+    hass: HomeAssistant, mock_api_with_streams
+):
+    """A-63: юзер выключил «Показывать на панели» в HA UI → hidden_by=USER →
+    skip. Hide через UI = «не хочу видеть данные» = stream бесполезен.
+    Чтобы вернуть — toggle обратно (hidden_by=None)."""
+    entry = _make_config_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    visible_uid = f"{DOMAIN}_camera_{VISIBLE_CAMERA_ID}"
+    visible_entity_id = registry.async_get_entity_id("camera", DOMAIN, visible_uid)
+    # Юзер выключил «Показывать на панели».
+    registry.async_update_entity(
+        visible_entity_id, hidden_by=er.RegistryEntryHider.USER
+    )
+
+    instance = mock_api_with_streams.return_value
+    instance.query_camera_stream.reset_mock()
+
+    visible_camera = _get_camera_entity(hass, visible_uid)
+    result = await visible_camera.stream_source()
+    assert result is None, (
+        f"USER-hidden camera stream_source должен вернуть None, got {result!r}"
+    )
+    assert instance.query_camera_stream.await_count == 0
+
+
+# ─── Test E: юзер включил «Показывать на панели» для INTEGRATION-hidden → отдаём
+
+
+async def test_stream_source_works_after_user_show_override(
+    hass: HomeAssistant, mock_api_with_streams
+):
+    """A-63: юзер развернул hidden-в-приложении камеру в HA UI и включил
+    «Показывать на панели» (hidden_by=None). Видео ДОЛЖНО работать —
+    это явный user choice (отдаёт пока наш sync не вернёт INTEGRATION,
+    что само по себе отдельная UX-проблема — см. follow-up в audit)."""
+    entry = _make_config_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    hidden_uid = f"{DOMAIN}_camera_{HIDDEN_CAMERA_ID}"
+    hidden_entity_id = registry.async_get_entity_id("camera", DOMAIN, hidden_uid)
+    # Precondition: после setup наш sync поставил INTEGRATION.
+    assert registry.async_get(hidden_entity_id).hidden_by == er.RegistryEntryHider.INTEGRATION
+
+    # Юзер включил «Показывать на панели» в HA UI.
+    registry.async_update_entity(hidden_entity_id, hidden_by=None)
+
+    instance = mock_api_with_streams.return_value
+    instance.query_camera_stream.reset_mock()
+
+    hidden_camera = _get_camera_entity(hass, hidden_uid)
+    result = await hidden_camera.stream_source()
+    assert result == "https://example/stream.flv", (
+        f"После user «Показывать на панели» stream должен работать, got {result!r}"
+    )
+    assert instance.query_camera_stream.await_count == 1


### PR DESCRIPTION
## Summary

Закрывает [A-63](docs/audit/project-audit.md) — HA core делает `stream_source()` для hidden cameras → лишние HTTP к operator API.

**Production-лог 2026-05-26:**
```
Camera init id=5593586 ... hidden=True
→ Fetching camera 5593586 stream URL
```

## Fix

`camera.py:_is_hidden()` skip-нет `stream_source()` / `async_camera_image()` БЕЗ обращения к coordinator если `registry_entry.hidden_by is not None` — **любой reason**:

- **INTEGRATION**: наш `_sync_visibility` пометил на основе API `hidden=True`;
- **USER**: юзер выключил «Показывать на панели» через HA UI;
- **DEVICE**: каскад от device-level (не используем сейчас).

Чтобы вернуть видео — toggle **«Показывать на панели»** в entity-edit page (HA устанавливает `hidden_by=None`).

## Дизайн-эволюция (через 3 итерации фидбэка)

| Версия | Логика | Issue |
|---|---|---|
| v1 | skip любой `hidden_by != None` | Юзер: «нашёл скрытую через Settings → Entities, хочу видео» |
| v2 | skip только `INTEGRATION + API hidden` | Юзер: «выключил Показывать на панели, stream тянется» |
| **v3 (final)** | skip любой `hidden_by != None`, toggle включает обратно | ✅ Соответствует ожиданиям |

## Known follow-up

Наш `_sync_visibility` сейчас overrides user «Показывать на панели» на следующем 5-min refresh (ставит `INTEGRATION` обратно). Это отдельная UX-проблема — войдёт в scope A-64 (sync_visibility semantics rewrite).

## Files

- `custom_components/elektronny_gorod/camera.py` — `_is_hidden()` + guards в `stream_source()` / `async_camera_image()` (+15/-3).
- `tests/test_camera_hidden_skip.py` — 5 unit-тестов (TDD strict).
- `CHANGELOG.md` — `[Unreleased] → Fixed`.
- `docs/audit/project-audit.md` — A-63 → ✅ RESOLVED + дизайн-эволюция.

## Test plan

- [x] **84 tests pass** (79 → +5 новых, no regression)
- [x] Test scenarios:
  1. INTEGRATION-hidden → skip, 0 API calls
  2. visible camera → стандартное поведение (regression guard)
  3. INTEGRATION-hidden snapshot → skip, 0 API calls
  4. USER-hidden → skip
  5. User override «Показывать на панели» (`hidden_by=None`) → stream работает
- [x] Manual UX testing на real install: toggle включает/выключает поток корректно

## Импакт

- **Экономия HTTP**: -1 запрос per hidden camera per `stream_source` call.
- **User UX**: «Показывать на панели» toggle = простой способ включить/выключить.
- **Backwards compat**: нет breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)