### PR TITLE
[VARIANT Z] fix(camera): A-66v3 — revert stream_source skip + update_source при PUT

### DIFF
--- a/custom_components/elektronny_gorod/camera.py
+++ b/custom_components/elektronny_gorod/camera.py
@@ -257,25 +257,43 @@ class ElektronnyGorodCamera(
             self._rtsp_url(),
         )
 
+        # A-66v3: если HA Stream worker уже running — force restart, чтобы
+        # новый ffmpeg producer (с свежим operator src) активировался немедленно.
+        # Без этого worker продолжает старое подключение, при истечении operator
+        # токена впадает в retry-with-backoff (10-60 сек).
+        # `update_source()` устанавливает `_fast_restart_once=True` +
+        # `_thread_quit.set()` (см. homeassistant.components.stream).
+        stream = self.stream
+        if stream is not None:
+            try:
+                stream.update_source(self._rtsp_url())
+                LOGGER.debug(
+                    "Camera %s (%s): forced HA Stream restart after go2rtc PUT",
+                    self._name, self._id,
+                )
+            except Exception:  # noqa: BLE001 — defensive: HA Stream API edge cases
+                LOGGER.exception(
+                    "Failed to update HA Stream source for camera %s (%s)",
+                    self._name, self._id,
+                )
+
     # ------------------------------------------------------------------ #
     # On-demand actions                                                  #
     # ------------------------------------------------------------------ #
 
     def _is_hidden(self) -> bool:
-        """A-63: skip stream/snapshot fetch если entity не показывается в UI.
+        """A-63 (PARTIAL): skip только для snapshot, НЕ для stream_source.
 
-        Skip когда `registry_entry.hidden_by is not None` — любой reason:
-        - INTEGRATION: наш `_sync_visibility` пометил на основе API hidden=True;
-        - USER: юзер выключил «Показывать на панели» через HA UI;
-        - DEVICE: каскад от device-level (не используем сейчас).
+        Используется ТОЛЬКО в `async_camera_image` — snapshot on-demand,
+        lifecycle проблем нет, skip безопасен.
 
-        Любой hidden = юзер не видит camera card в UI = HTTP/stream бесполезен.
-        Чтобы включить обратно — toggle «Показывать на панели» в entity-edit
-        page (HA устанавливает `hidden_by=None`).
-
-        `registry_entry` is None в окне между `__init__` и `async_added_to_hass` —
-        safe default «не скрыто» (этот код всё равно вызывается уже после
-        async_added_to_hass, но guard на всякий случай).
+        Для `stream_source` skip убран (см. A-66v3): HA Stream worker pin-ится
+        к RTSP URL который мы вернули один раз; `stream_source` повторно не
+        вызывается. Если мы возвращаем None после того как stream была
+        активна, worker зависает в retry-loop на устаревшем RTSP/producer.
+        Лучше всегда возвращать живой URL + полагаться на HA prefetch для
+        обновления go2rtc producer + Stream.update_source() для force restart
+        при изменении src в go2rtc.
         """
         reg = self.registry_entry
         return reg is not None and reg.hidden_by is not None
@@ -292,9 +310,14 @@ class ElektronnyGorodCamera(
         return self._image
 
     async def stream_source(self) -> str | None:
-        """Return the source of the stream."""
-        if self._is_hidden():
-            return None
+        """Return the source of the stream.
+
+        НЕ skip-аем для hidden (см. A-66v3). HA Stream lifecycle несовместим
+        с возвратом None после того как stream была активна — worker зависает.
+        Operator FLV URL c коротким TTL обновляется через постоянный prefetch
+        + `Stream.update_source()` в `_ensure_go2rtc_stream` форсит worker
+        restart при изменении operator src.
+        """
         stream_url = await self.coordinator.get_camera_stream(self._id)
         if not stream_url:
             LOGGER.warning("Camera %s (%s): empty source stream url", self._name, self._id)

--- a/tests/test_camera_hidden_skip.py
+++ b/tests/test_camera_hidden_skip.py
@@ -135,11 +135,17 @@ def _get_camera_entity(hass: HomeAssistant, unique_id: str):
 # ─── Test A: hidden camera — stream_source returns None, no API call ─────────
 
 
-async def test_stream_source_returns_none_for_hidden_camera(
+async def test_stream_source_returns_url_for_hidden_camera_v3(
     hass: HomeAssistant, mock_api_with_streams
 ):
-    """A-63: hidden_by=INTEGRATION → stream_source() возвращает None
-    БЕЗ вызова coordinator.get_camera_stream → API."""
+    """A-66v3: hidden_by=INTEGRATION → stream_source() ВСЁ РАВНО возвращает URL.
+
+    Skip для stream_source убран (см. A-66v3): HA Stream worker pin-ится к
+    RTSP URL который мы вернули один раз; повторно stream_source не
+    вызывается. Если возвращаем None после того как stream была активна,
+    worker зависает в retry-loop. Skip применяется ТОЛЬКО к snapshot
+    (async_camera_image — on-demand, lifecycle проблем нет).
+    """
     entry = _make_config_entry()
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -151,22 +157,18 @@ async def test_stream_source_returns_none_for_hidden_camera(
     hidden_camera = _get_camera_entity(
         hass, f"{DOMAIN}_camera_{HIDDEN_CAMERA_ID}"
     )
-    assert hidden_camera is not None, "hidden camera entity должна существовать (state machine работает)"
+    assert hidden_camera is not None
 
-    # Sanity: registry_entry правда hidden_by=INTEGRATION (precondition).
+    # Precondition.
     registry = er.async_get(hass)
-    reg_entry = registry.async_get(hidden_camera.entity_id)
-    assert reg_entry.hidden_by == er.RegistryEntryHider.INTEGRATION, (
-        f"precondition: hidden camera должна иметь hidden_by=INTEGRATION, "
-        f"got {reg_entry.hidden_by!r}"
-    )
+    assert registry.async_get(hidden_camera.entity_id).hidden_by == er.RegistryEntryHider.INTEGRATION
 
     result = await hidden_camera.stream_source()
-    assert result is None, f"stream_source() для hidden должен вернуть None, got {result!r}"
-    assert instance.query_camera_stream.await_count == 0, (
-        f"query_camera_stream НЕ должен вызываться для hidden camera, "
-        f"got call_count={instance.query_camera_stream.await_count}"
+    assert result == "https://example/stream.flv", (
+        f"v3: hidden camera stream_source ВСЁ РАВНО возвращает URL (HA Stream "
+        f"lifecycle requirement), got {result!r}"
     )
+    assert instance.query_camera_stream.await_count == 1
 
 
 # ─── Test B: visible camera — поведение не меняется ──────────────────────────
@@ -235,12 +237,11 @@ async def test_async_camera_image_returns_none_for_hidden_camera(
 # ─── Test D: USER-hidden — skip (юзер отключил «Показывать на панели») ──────
 
 
-async def test_stream_source_returns_none_for_user_hidden_camera(
+async def test_stream_source_returns_url_for_user_hidden_camera_v3(
     hass: HomeAssistant, mock_api_with_streams
 ):
-    """A-63: юзер выключил «Показывать на панели» в HA UI → hidden_by=USER →
-    skip. Hide через UI = «не хочу видеть данные» = stream бесполезен.
-    Чтобы вернуть — toggle обратно (hidden_by=None)."""
+    """A-66v3: USER hidden_by → stream_source() всё равно возвращает URL
+    (HA Stream lifecycle requirement). Snapshot skip — отдельно."""
     entry = _make_config_entry()
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -259,10 +260,10 @@ async def test_stream_source_returns_none_for_user_hidden_camera(
 
     visible_camera = _get_camera_entity(hass, visible_uid)
     result = await visible_camera.stream_source()
-    assert result is None, (
-        f"USER-hidden camera stream_source должен вернуть None, got {result!r}"
+    assert result == "https://example/stream.flv", (
+        f"v3: USER-hidden stream_source всё равно возвращает URL, got {result!r}"
     )
-    assert instance.query_camera_stream.await_count == 0
+    assert instance.query_camera_stream.await_count == 1
 
 
 # ─── Test E: юзер включил «Показывать на панели» для INTEGRATION-hidden → отдаём


### PR DESCRIPTION
## VARIANT Z из эксперимента

⚠️ **Один из 3-х параллельных PR для сравнения.** Не мержить — для review/тестирования рядом с другими.

| PR | Подход |
|---|---|
| #44 | VARIANT X: `_was_hidden` flag + invalidate `_last_src` (skip везде) |
| #45 | VARIANT Y: registry listener (hide=stop, unhide=pickup) (skip везде) |
| **#46** | **VARIANT Z: revert stream_source skip + update_source при PUT** ← этот |

## Подход (минималистичный, без registry events)

1. `_is_hidden()` оставлен, используется **только в `async_camera_image`**. Snapshot on-demand, lifecycle проблем нет.
2. **`stream_source` БОЛЬШЕ НЕ skip-ает для hidden** — всегда возвращает живой URL. HA Stream получает корректный source, lifecycle работает as designed.
3. `_ensure_go2rtc_stream`: после каждого PUT в go2rtc → `Stream.update_source(rtsp_url)` если worker running. Force restart worker с обновлённым go2rtc producer, избегаем 10-30s backoff.

## Что должно решить

- ✅ «после hide остаётся пустой stream»: HA Stream lifecycle работает — никаких zombie sessions.
- ✅ «после unhide долго не подгружает»: либо HA prefetch регулярно обновляет URL, либо update_source форсит restart при PUT.
- ❌ A-63 НЕ закрыт — лишние HTTP для hidden cameras возвращаются (но это <10-15 req/час на cam, приемлемо).

## Архитектурные плюсы / минусы vs других вариантов

**Плюсы:**
- **Минимум кода**: +27 LOC vs +106 (Y) или +34 (X).
- HA Stream lifecycle работает as designed — никаких хаков.
- Никаких event-bus listeners.
- Никаких instance flags / state tracking.

**Минусы:**
- A-63 revert частично — лишний HTTP overhead возвращается для hidden.
- Cost-benefit: лишние HTTP vs broken video → лишние HTTP меньшее зло.

## Files

- `custom_components/elektronny_gorod/camera.py` — +24/-4 (revert skip + update_source)
- `tests/test_camera_hidden_skip.py` — 2 теста обновлены под variant Z behavior

## Test plan

- [x] 89 tests pass (no regression)
- [ ] Manual: deploy на home.server, проверить:
  1. Toggle OFF visible camera → stream продолжает работать пока playback идёт, аккуратно cleanup-нет при close (HA-native lifecycle)
  2. Toggle ON hidden camera → видео грузится сразу (HA prefetch уже подтянул свежий URL)
  3. Длительный playback без interruption (update_source освежает каждый раз когда operator URL меняется)

🤖 Generated with [Claude Code](https://claude.com/claude-code)