### PR TITLE
chore(ci): auto-cleanup PR pre-releases on close

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -2,13 +2,13 @@ name: PR Pre-Release
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, closed]
     paths:
       - 'custom_components/**'
 
 jobs:
   prerelease:
-    if: github.event.pull_request.draft == false
+    if: github.event.action != 'closed' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,3 +34,17 @@ jobs:
           files: custom_components/elektronny_gorod/elektronny_gorod.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete pre-release and tag
+        run: |
+          gh release delete "pr-${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --yes --cleanup-tag || echo "No pre-release for this PR — nothing to delete."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### CI
+
+- **PR pre-release auto-cleanup**. Workflow `.github/workflows/prerelease.yaml` теперь слушает `pull_request:closed` и удаляет `pr-NN` release + tag через `gh release delete --cleanup-tag`. Раньше pre-releases накапливались (15+ висящих для merged PR на момент 2026-05-26) — теперь GitHub Releases остаются чистыми, в списке видны только настоящие версии и активные PR pre-releases. Разовая чистка: удалены pr-25, pr-27, pr-31..35, pr-38..40, pr-42..45.
+
 ### Fixed
 
 - **Visibility sync: reload cascade + user override** ([A-64](docs/audit/project-audit.md)). Раньше cold start давал **4× reload в 34 сек** (production-лог 2026-05-26): `_migrate_legacy_disabled_state` писал flag в `entry.options` → triggers `async_update_options` listener → `async_reload` → setup_entry; параллельно setup триггерил reload через `migration_changed or sync_changed`. Помимо этого `_sync_visibility` на каждом setup восстанавливал `INTEGRATION` для hidden-в-API камер — перезаписывал юзерский выбор «Показывать на панели» (через 5 мин камера снова hidden в HA UI). **Изменения**: (1) migration flag перенесён в `entry.data` (НЕ триггерит options-listener); backward-compat читает оба места, переносит при первом setup; (2) explicit `async_reload` теперь только при `migration_changed` — sync visibility это live registry update, reload не нужен; (3) `_sync_visibility` track per-entity flags через `entity.options[DOMAIN]` (persistent, не триггерит entry-listener): `we_set_integration` — наша отметка, `user_shown` — детектится когда мы set INTEGRATION, а registry уже None (юзер кликнул «Показывать на панели»). С `user_shown=True` мы НЕ восстанавливаем INTEGRATION даже если API hidden. При un-hide в приложении (API visible) — `user_shown` auto-clear. 5 новых тестов (`tests/test_visibility_user_override.py`). USER hidden_by override продолжает уважаться (regression-guard).


### PR DESCRIPTION
## Summary

- Workflow `.github/workflows/prerelease.yaml` теперь слушает `pull_request:closed` и удаляет `pr-NN` release + tag — pre-releases не накапливаются для merged/closed PR.
- Существующее создание pre-release при opened/synchronize/reopened/ready_for_review сохранено (skip только когда `action=closed`).
- Разовая чистка через `gh release delete` уже выполнена: удалены pr-25, pr-27, pr-31..35, pr-38..40, pr-42..45 (15 штук). Остался только `pr-46` (OPEN).

## Why

До правки на странице GitHub Releases висело 15+ pre-releases для уже merged/closed PR — мусор, который путает пользователей при поиске реальных версий (v3.1.0, 3.0.x). Теперь cleanup автоматизирован.

## Files

- `.github/workflows/prerelease.yaml` — `+ types: closed`, новый job `cleanup` (`if: action == 'closed'`).
- `CHANGELOG.md` — секция `[Unreleased] → CI`.

## Test plan

- [ ] Merge этот PR → action `pull_request:closed` запустится → job `cleanup` попытается удалить `pr-47` (не существует) → fallback `|| echo` отработает чисто.
- [ ] Следующий feat/fix PR с правками в `custom_components/**` создаст `pr-NN` pre-release как обычно.
- [ ] После merge/close следующего PR — `pr-NN` исчезнет из `gh release list` автоматически.

🤖 Generated with [Claude Code](https://claude.com/claude-code)