### PR TITLE
chore(gitignore): ignore .playwright-mcp/ runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ logs/
 
 # HA / integration zip от release workflow (если случайно собран локально)
 custom_components/elektronny_gorod/elektronny_gorod.zip
+
+# Playwright MCP runtime artifacts (console-*.log, page-*.yml snapshots)
+.playwright-mcp/


### PR DESCRIPTION
## Summary

Playwright MCP создаёт `.playwright-mcp/` в корне проекта с runtime артефактами при использовании browser-tools (console-*.log, page-*.yml). Это локальный debug-state, не должен попадать в commits.

## Files

- `.gitignore` — `+3 строки` (комментарий + `.playwright-mcp/`)

## Test plan

- [x] `git status` чист после добавления
- [x] Pure chore (без runtime impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)