### PR TITLE
chore(release): mark 3.2.0 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-05-27
+
 ### Changed (Camera resilience)
 
-- **Camera: dedup concurrent `stream_source()` calls** ([A-68](docs/audit/project-audit.md)). Production-лог 2026-05-27 12:59:21 показал **two concurrent `Fetching camera 5593578 stream URL` за 13 мс** — это не retry-цепочка (HA Stream `STREAM_RESTART_INCREMENT` ≥ 5 сек), а два независимых caller'а (HA Stream worker + другой источник: Frigate / WebRTC probe / Lovelace card preview). Каждый concurrent caller делал отдельный HTTP к operator (свежий session token) + PUT в go2rtc + `Stream.update_source()` restart — defensive thrash без пользы. **Fix**: in-flight future-pattern в `stream_source()`. Если concurrent caller видит уже идущий запрос — wait его future вместо запуска параллельного. N concurrent callers → **1 HTTP + 1 PUT + 1 restart** вместо N. Future cleared в `finally` блоке → sequential calls после batch делают свежий fetch. 5 unit-тестов (`tests/test_camera_stream_dedup.py`). **Scope clarification**: это defensive concurrency cleanup. Видимое «мигание видео после cold start», наблюдаемое в production-тестах, **не устранилось** этим патчем — у него отдельный root cause (изучение перенесено в отдельный track).
+- **Camera: dedup concurrent `stream_source()` calls** ([A-68](docs/audit/project-audit.md)). Production-лог 2026-05-27 12:59:21 показал **two concurrent `Fetching camera 5593578 stream URL` за 13 мс** — это не retry-цепочка (HA Stream `STREAM_RESTART_INCREMENT` ≥ 5 сек), а два независимых caller'а (HA Stream worker + другой источник: Frigate / WebRTC probe / Lovelace card preview). Каждый concurrent caller делал отдельный HTTP к operator (свежий session token) + PUT в go2rtc + `Stream.update_source()` restart — defensive thrash без пользы. **Fix**: in-flight future-pattern в `stream_source()`. Если concurrent caller видит уже идущий запрос — wait его future вместо запуска параллельного. N concurrent callers → **1 HTTP + 1 PUT + 1 restart** вместо N. Future cleared в `finally` блоке → sequential calls после batch делают свежий fetch. 5 unit-тестов (`tests/test_camera_stream_dedup.py`).
 
 ### CI
 


### PR DESCRIPTION
## Summary

Bump CHANGELOG: `[Unreleased]` → `[3.2.0] - 2026-05-27` для предстоящего GitHub release.

manifest.json `version` обновится автоматически workflow [`release.yaml`](.github/workflows/release.yaml) после публикации тега (на `release:published` event).

## Release scope (3.2.0)

- **Added**: DnD switches (A-56), balance `account_blocked` binary_sensor + `days_to_block` sensor (A-57)
- **Changed**: coordinator HTTP dedup per-place (A-61), camera concurrent `stream_source()` dedup (A-68)
- **Fixed**: visibility sync reload cascade + user override (A-64), camera log throttling (A-65), camera hidden skip + go2rtc auto-refresh (A-63/A-66)
- **CI**: PR pre-release auto-cleanup

## Files

- `CHANGELOG.md` — `+3 / -1`: добавлен `[3.2.0] - 2026-05-27` header, очищен A-68 entry от scope-clarification tail (не для CHANGELOG аудитории).

## Test plan

- [x] `[Unreleased]` остался пустым placeholder сверху
- [x] `[3.2.0]` идёт между `[Unreleased]` и `[3.1.0]`
- [x] Pure docs (без runtime impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)