### PR TITLE
feat(diagnostics): diagnostics.py с redaction (A-23 / S-08 / S-16)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ custom_components/elektronny_gorod/
 ├── binary_sensor.py       # account_blocked
 ├── switch.py              # DND switches (intercom / management calls)
 ├── go2rtc.py              # validate_go2rtc + cleanup
+├── diagnostics.py         # redact-нутая diagnostics-выгрузка (TO_REDACT)
 ├── entity_migration.py    # стабильные unique_id + registry migration
 ├── helpers.py             # find, dedupe, hash_password (SHA1+MD5)
 ├── user_agent.py          # эмуляция Android-клиента (Pixel 6-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-05-30
+
+### Added
+
+- **Diagnostics с redaction** ([A-23](docs/audit/project-audit.md) / [S-08](docs/audit/security.md)). Добавлен `diagnostics.py` — теперь выгрузку diagnostics через UI можно безопасно расшарить: `async_redact_data(entry.as_dict(), TO_REDACT)` маскирует `access_token`/`refresh_token`/`user_agent`/go2rtc creds + PII (account_id, subscriber_id, phone, …). `TO_REDACT` синхронизирован с `SENSITIVE_KEYS` (`_logging.py`, есть guard-тест). Coordinator-снимок в выгрузке — только счётчики (places/cameras/locks/balances/dnd), без значений. Закрывает S-16 (go2rtc creds больше не утекают в diagnostics). 6 тестов `tests/test_diagnostics.py`.
+
+### Changed
+
+- **AIDD: state-management + reconciliation findings↔git** ([ADR-0010](docs/decisions/0010-aidd-state-reconciliation.md), internal). Устранён системный дрейф документации: контракты (`AGENTS.md`/`CLAUDE.md`/`workflow.md`) больше не описывают исправленный код как сломанный; audit-статусы `RESOLVED` сверяются с git master (`.claude/hooks/check-audit-reconciliation.sh`, SessionStart hook); «текущее состояние» живёт в одном источнике; maintenance-rules стали двунаправленными; гейты блокируют (`quality_scale ≤ gate-confirmed`). Не затрагивает код интеграции.
+
 ### Fixed
 
 - **Options flow: нельзя было очистить go2rtc creds (silent save без изменений)** ([A-78](docs/audit/project-audit.md)). Юзер открывал «Настройки go2rtc», очищал username/password, нажимал save → форма говорила «Параметры успешно сохранены», но при следующем открытии creds **снова на месте**. Никакой ошибки — просто silent revert. Root cause: schema использовала `vol.Optional(KEY, default=str(old_value))` — HA frontend омит пустые Optional поля при submit, voluptuous подставляет default **обратно** → user_input получает старое значение → save «успешен» без изменений. **Fix**: канонический HA pattern — schema без default для username/password, текущие значения подаются через `add_suggested_values_to_schema` (подсказка в UI, но пустой submit остаётся пустым). Бонус: `validate_go2rtc` теперь различает HTTP 401 (auth_failed) от других сетевых ошибок (unreachable) — error message указывает чёткий путь решения. 3 regression-теста в `tests/test_options_flow_clear_creds.py`.

--- a/custom_components/elektronny_gorod/diagnostics.py
+++ b/custom_components/elektronny_gorod/diagnostics.py
@@ -1,0 +1,60 @@
+"""Diagnostics для Elektronny Gorod (S-08 / S-16 / A-23, ADR-0004).
+
+HA по умолчанию при экспорте diagnostics дампит `entry.data`/`entry.options`
+целиком — там access_token / refresh_token / go2rtc creds / user_agent
+(с account_id). Этот модуль маскирует их через `async_redact_data`, чтобы
+пользователь мог безопасно поделиться диагностикой.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from ._logging import SENSITIVE_KEYS
+from .const import (
+    CONF_ACCOUNT_ID,
+    CONF_CONTRACT,
+    CONF_OPERATOR_ID,
+    CONF_PHONE,
+    CONF_SUBSCRIBER_ID,
+    DOMAIN,
+)
+
+# Источник правды по секретам — SENSITIVE_KEYS из _logging.py (ADR-0004).
+# Дополняем PII-идентификаторами, которые не секреты, но не должны утекать в
+# публично расшаренную diagnostics-выгрузку.
+TO_REDACT: frozenset[str] = SENSITIVE_KEYS | {
+    CONF_PHONE,
+    CONF_CONTRACT,
+    CONF_OPERATOR_ID,
+    CONF_ACCOUNT_ID,
+    CONF_SUBSCRIBER_ID,
+    "name",
+    "address",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Вернуть redact-нутую диагностику config entry."""
+    diagnostics: dict[str, Any] = {
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+    }
+
+    # Снимок coordinator — только счётчики (без значений/PII).
+    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    data = getattr(coordinator, "data", None)
+    if isinstance(data, dict):
+        diagnostics["coordinator"] = {
+            "places": len(data.get("places") or []),
+            "cameras": len(data.get("cameras") or {}),
+            "locks": len(data.get("locks") or {}),
+            "balances": len(data.get("balances") or {}),
+            "dnd": bool(data.get("dnd")),
+        }
+
+    return diagnostics

--- a/docs/audit/project-audit.md
+++ b/docs/audit/project-audit.md
@@ -208,9 +208,13 @@ Quality gates:
 
 ### A-23. Отсутствует `diagnostics.py`
 
-- **Area:** HA-compat
-- **Evidence:** в `custom_components/elektronny_gorod/` нет файла.
-- **Recommended fix:** см. [`SECURITY_AUDIT.md#S-08`](../audit/security.md).
+- **Status:** ✅ **RESOLVED** — добавлен `diagnostics.py` с
+  `async_get_config_entry_diagnostics` + `async_redact_data(TO_REDACT)`.
+  `TO_REDACT = SENSITIVE_KEYS ∪ PII-идентификаторы` (синхронизирован с
+  `_logging.py`). Coordinator-снимок — только счётчики, без значений.
+  6 тестов `tests/test_diagnostics.py`. Закрывает
+  [`security.md#S-08`](security.md) и [`#S-16`](security.md).
+- **Area:** HA-compat / Security
 
 ### A-24. Нет workflow для pytest
 
@@ -326,6 +330,10 @@ Quality gates:
 
 ### A-45. go2rtc credentials в `entry.data` plaintext
 
+- **Status:** 🟡 **MITIGATED** — creds по-прежнему в `entry.data`/`entry.options`
+  plaintext (HA-storage limitation), но больше **не утекают** в diagnostics:
+  `go2rtc_username`/`go2rtc_password` в `TO_REDACT` (A-23 / S-16). Полное
+  шифрование (`Store`/pin) — отдельный backlog-пункт, не блокер.
 - **Severity:** P1 (security)
 - **Evidence:** [`config_flow.py:362`](../../custom_components/elektronny_gorod/config_flow.py#L362), [`config_flow.py:419-420`](../../custom_components/elektronny_gorod/config_flow.py#L419-L420); подробно — в [`security.md#S-16`](security.md).
 - **Recommended fix:** добавить `go2rtc_username`/`go2rtc_password` в `TO_REDACT` для diagnostics.py (см. S-08).

--- a/docs/audit/security.md
+++ b/docs/audit/security.md
@@ -113,11 +113,14 @@ v3.2.0): grep всех `LOGGER.*` в чувствительных файлах +
 
 ### S-08. Отсутствие diagnostics.py с redaction
 
-- **Status:** 🔴 **STILL OPEN** (P1) — подтверждено 2026-05-30,
-  `ls custom_components/elektronny_gorod/diagnostics.py` → No such file.
-  Это блокирует `SECURITY_OK` gate и Silver IQS (`diagnostics` rule).
-- **Файл:** ❌
-- **Impact:** когда пользователь экспортирует diagnostics через UI — HA по умолчанию пытается дампить `entry.data` целиком (через `async_get_config_entry_diagnostics`). Без нашего `diagnostics.py` пользователь не может безопасно поделиться диагностикой.
+- **Status:** ✅ **RESOLVED** — добавлен `diagnostics.py` (3.3.0).
+  `async_get_config_entry_diagnostics` → `async_redact_data(entry.as_dict(), TO_REDACT)`.
+  `TO_REDACT = SENSITIVE_KEYS ∪ {phone, contract, operator_id, account_id,
+  subscriber_id, name, address}` (синхронизирован с `_logging.py`; есть тест
+  `test_to_redact_covers_sensitive_keys`). Coordinator-снимок — только счётчики.
+  6 тестов `tests/test_diagnostics.py`. Разблокирует `SECURITY_OK`.
+- **Файл:** [`diagnostics.py`](../../custom_components/elektronny_gorod/diagnostics.py)
+- **Original Impact:** когда пользователь экспортирует diagnostics через UI — HA по умолчанию пытается дампить `entry.data` целиком (через `async_get_config_entry_diagnostics`). Без нашего `diagnostics.py` пользователь не может безопасно поделиться диагностикой.
 - **Fix:** создать `diagnostics.py`:
   ```python
   TO_REDACT = {
@@ -132,10 +135,14 @@ v3.2.0): grep всех `LOGGER.*` в чувствительных файлах +
 
 ### S-16. go2rtc credentials в `entry.data` plaintext
 
+- **Status:** 🟡 **MITIGATED** — `go2rtc_username`/`go2rtc_password` в `TO_REDACT`
+  → больше **не утекают** в diagnostics-выгрузку (S-08 RESOLVED). Остаётся
+  plaintext в `.storage`/backup (HA-storage limitation) — полное шифрование
+  (`Store`/pin) в backlog, не блокер.
 - **Файлы:** [`config_flow.py:362`](../../custom_components/elektronny_gorod/config_flow.py#L362), [`config_flow.py:419-420`](../../custom_components/elektronny_gorod/config_flow.py#L419-L420), [`camera.py:166-170`](../../custom_components/elektronny_gorod/camera.py#L166-L170)
-- **Severity:** P1
-- **Impact:** `go2rtc_password` (Basic Auth) хранится в `entry.data` без шифрования. Попадёт в diagnostics-выгрузку (S-08), в backup HA, в `.storage/core.config_entries`.
-- **Fix:** добавить ключи в `TO_REDACT`. Долгосрочно — рассмотреть HA `auth_storage` / `Store` с pin-кодом.
+- **Severity:** P1 → P3 (после mitigation)
+- **Impact:** `go2rtc_password` (Basic Auth) хранится в `entry.data` без шифрования. ~~Попадёт в diagnostics-выгрузку (S-08)~~ — закрыто redaction.
+- **Fix:** ✅ ключи в `TO_REDACT`. Долгосрочно — рассмотреть HA `Store` с pin-кодом.
 - **Дополнительно:** в [`camera.py:167`](../../custom_components/elektronny_gorod/camera.py#L167) `import base64` находится внутри метода — функционально безопасно, но плохая практика (плюс auth-header строится «вручную» вместо `aiohttp.BasicAuth`).
 
 ### S-09. Нет timeout на HTTP-запросы

--- a/docs/project/project-map.md
+++ b/docs/project/project-map.md
@@ -56,10 +56,15 @@ elektronny-gorod/
 │   ├── coordinator.py             ← DataUpdateCoordinator
 │   ├── api.py                     ← REST API клиент
 │   ├── http.py                    ← низкоуровневый HTTP
-│   ├── camera.py                  ← Camera platform
+│   ├── _logging.py                ← redact() + SENSITIVE_KEYS (ADR-0004)
+│   ├── camera.py                  ← Camera platform + go2rtc + auto-recovery
 │   ├── lock.py                    ← Lock platform
-│   ├── sensor.py                  ← Sensor (balance) platform
+│   ├── sensor.py                  ← Sensor (balance + days-to-block) platform
+│   ├── binary_sensor.py           ← account_blocked platform
+│   ├── switch.py                  ← DND switches platform
 │   ├── go2rtc.py                  ← go2rtc валидация / upsert
+│   ├── entity_migration.py        ← стабильные unique_id + registry migration
+│   ├── diagnostics.py             ← redact-нутая diagnostics-выгрузка (S-08)
 │   ├── helpers.py                 ← utils + auth crypto
 │   ├── user_agent.py              ← эмуляция Android-клиента
 │   ├── time.py                    ← timestamp helpers
@@ -69,9 +74,9 @@ elektronny-gorod/
 │       ├── ru.json
 │       └── en.json
 │
-├── tests/                          ← 🔴 нерабочий stub
+├── tests/                          ← pytest suite (PHC-based, зелёный)
 │   ├── conftest.py
-│   └── test_config_flow.py
+│   └── …                          ← см. таблицу тестов ниже
 │
 ├── .github/workflows/
 │   ├── hassfest.yaml              ← manifest validation
@@ -142,6 +147,13 @@ elektronny-gorod/
 |---|---|
 | [`go2rtc.py`](../../custom_components/elektronny_gorod/go2rtc.py) | validate_go2rtc (GET /api + PUT /api/streams + cleanup), upsert stream, derive_rtsp_host |
 
+### Diagnostics / безопасность
+
+| Файл | Назначение |
+|---|---|
+| [`_logging.py`](../../custom_components/elektronny_gorod/_logging.py) | `redact()` + `SENSITIVE_KEYS` + `redact_path()` (ADR-0004) |
+| [`diagnostics.py`](../../custom_components/elektronny_gorod/diagnostics.py) | `async_get_config_entry_diagnostics` + `TO_REDACT` (S-08/S-16); coordinator-снимок = только счётчики |
+
 ### Утилиты
 
 | Файл | Назначение | Особенности |
@@ -166,6 +178,7 @@ elektronny-gorod/
 | [`tests/conftest.py`](../../tests/conftest.py) | fixtures + `enable_custom_integrations` auto-applied |
 | [`tests/test_entity_migration.py`](../../tests/test_entity_migration.py) | unit-тесты `_camera_new_uid`/`_lock_new_uid` + golden vector для `lock_unique_id` |
 | [`tests/test_logging_redact.py`](../../tests/test_logging_redact.py) | unit-тесты `_logging.redact()` + `redact_path()` |
+| [`tests/test_diagnostics.py`](../../tests/test_diagnostics.py) | redaction secrets/options, non-sensitive preserved, coordinator counts-only, TO_REDACT ⊇ SENSITIVE_KEYS |
 | [`tests/test_http.py`](../../tests/test_http.py) | Bearer skip на pre-auth, no-leak между запросами, PII redact в error log |
 | [`tests/test_visibility.py`](../../tests/test_visibility.py) | hidden_by sync (first_add, USER override, un-hide, re-add) |
 | [`tests/test_visibility_real.py`](../../tests/test_visibility_real.py) | production-replica (реальные HAR-данные) + migration v2 |

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -72,10 +72,12 @@ Home Assistant **custom integration** [`elektronny_gorod`](../custom_components/
 ### P1 — важные (открыты)
 
 1. **Нет `ClientTimeout` на основном operator API** — [`http.py:110,112`](../custom_components/elektronny_gorod/http.py#L110-L112). Зависший запрос к `myhome.proptech.ru` блокирует coordinator tick / setup бессрочно. ⚠️ `ha-compatibility.md` ошибочно помечает это fixed. (A-21 / S-09)
-2. **`diagnostics.py` отсутствует** — при экспорте diagnostics HA дампит `entry.data` целиком (токены, go2rtc_password). Блокирует SECURITY_OK + Silver IQS. (A-23 / S-08 / S-16)
-3. **config_flow + миграции v1→2→3 без тестов** — `config_flow.py` 15% coverage, `async_migrate_entry` не покрыт. Bronze IQS требует config-flow-test-coverage → заявленный `quality_scale: bronze` пока не defensible. (A-73)
-4. **`helpers.py` crypto без golden vectors** — изменение формата бэкенда молча сломает auth. (A-74)
-5. **Native reauth / reconfigure flow отсутствуют** (A-25/A-26 — Silver/Gold).
+2. **config_flow + миграции v1→2→3 без тестов** — `config_flow.py` 15% coverage, `async_migrate_entry` не покрыт. Bronze IQS требует config-flow-test-coverage → заявленный `quality_scale: bronze` пока не defensible. (A-73)
+3. **`helpers.py` crypto без golden vectors** — изменение формата бэкенда молча сломает auth. (A-74)
+4. **Native reauth / reconfigure flow отсутствуют** (A-25/A-26 — Silver/Gold).
+
+✅ Закрыто в 3.3.0: `diagnostics.py` с redaction (A-23 / S-08; S-16 mitigated) —
+SECURITY_OK разблокирован.
 
 ### P2 — желательно
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,137 @@
+"""Тесты diagnostics redaction (S-08 / S-16 / A-23).
+
+Гарантируют, что выгрузка diagnostics через HA UI НЕ содержит секретов
+(access_token, refresh_token, go2rtc creds, user_agent с account_id) и PII.
+См. ADR-0004 (token redaction), docs/audit/security.md#S-08.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.redact import REDACTED
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.elektronny_gorod.const import DOMAIN
+from custom_components.elektronny_gorod.diagnostics import (
+    TO_REDACT,
+    async_get_config_entry_diagnostics,
+)
+
+_SECRET_MARKERS = (
+    "supersecret-access",
+    "supersecret-refresh",
+    "go2rtc-pass-secret",
+    "go2rtc-user-secret",
+    "Pixel 7; account=1131686",  # user_agent несёт account_id
+)
+
+
+def _make_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Электронный город",
+        data={
+            "access_token": "supersecret-access",
+            "refresh_token": "supersecret-refresh",
+            "user_agent": "Pixel 7; account=1131686",
+            "operator_id": 42,
+            "account_id": 1131686,
+            "subscriber_id": 999,
+            "use_go2rtc": True,
+            "go2rtc_base_url": "http://127.0.0.1:1984",
+            "go2rtc_username": "go2rtc-user-secret",
+            "go2rtc_password": "go2rtc-pass-secret",
+        },
+        options={
+            "go2rtc_username": "go2rtc-user-secret",
+            "go2rtc_password": "go2rtc-pass-secret",
+        },
+    )
+
+
+async def test_diagnostics_redacts_all_secrets(hass: HomeAssistant) -> None:
+    """Ни один секрет/креденшл не должен попасть в выгрузку (даже как substring)."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    blob = json.dumps(diag, default=str, ensure_ascii=False)
+
+    for marker in _SECRET_MARKERS:
+        assert marker not in blob, f"Секрет утёк в diagnostics: {marker!r}"
+
+    data = diag["entry"]["data"]
+    assert data["access_token"] == REDACTED
+    assert data["refresh_token"] == REDACTED
+    assert data["user_agent"] == REDACTED
+    assert data["go2rtc_username"] == REDACTED
+    assert data["go2rtc_password"] == REDACTED
+
+
+async def test_diagnostics_redacts_options(hass: HomeAssistant) -> None:
+    """go2rtc creds из entry.options тоже редактятся (S-16)."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    options = diag["entry"]["options"]
+    assert options["go2rtc_password"] == REDACTED
+    assert options["go2rtc_username"] == REDACTED
+
+
+async def test_diagnostics_keeps_non_sensitive(hass: HomeAssistant) -> None:
+    """Несекретные поля сохраняются — diagnostics должна быть полезной."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    data = diag["entry"]["data"]
+    assert data["use_go2rtc"] is True
+    assert data["go2rtc_base_url"] == "http://127.0.0.1:1984"
+
+
+async def test_diagnostics_coordinator_snapshot_is_counts_only(
+    hass: HomeAssistant,
+) -> None:
+    """Если coordinator есть — отдаём только счётчики, без PII/значений."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    class _FakeCoordinator:
+        data = {
+            "places": [{"id": 1}, {"id": 2}],
+            "cameras": {"c1": {}, "c2": {}, "c3": {}},
+            "locks": {"l1": {}},
+            "balances": {"b1": {}},
+            "dnd": {"root": True},
+        }
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _FakeCoordinator()
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    snap = diag["coordinator"]
+    assert snap == {
+        "places": 2,
+        "cameras": 3,
+        "locks": 1,
+        "balances": 1,
+        "dnd": True,
+    }
+
+
+async def test_diagnostics_without_coordinator(hass: HomeAssistant) -> None:
+    """Без coordinator в hass.data — diagnostics не падает, секция отсутствует."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    assert "coordinator" not in diag
+
+
+def test_to_redact_covers_sensitive_keys() -> None:
+    """TO_REDACT должен покрывать все SENSITIVE_KEYS (синхронизация с _logging.py)."""
+    from custom_components.elektronny_gorod._logging import SENSITIVE_KEYS
+
+    assert SENSITIVE_KEYS <= TO_REDACT


### PR DESCRIPTION
## Summary

Добавлен `diagnostics.py` — закрывает давний P1 (S-08): без него HA при экспорте diagnostics дампит `entry.data`/`entry.options` целиком (токены, go2rtc creds, user_agent с account_id). Это **разблокирует `SECURITY_OK` gate** перед релизом 3.3.0.

## Что сделано
- `async_get_config_entry_diagnostics` → `async_redact_data(entry.as_dict(), TO_REDACT)`.
- `TO_REDACT = SENSITIVE_KEYS` (`_logging.py`, ADR-0004) **∪** PII (phone, contract, operator_id, account_id, subscriber_id, name, address). Guard-тест гарантирует `SENSITIVE_KEYS ⊆ TO_REDACT`.
- Coordinator-снимок — только счётчики, без значений.
- A-23 → RESOLVED, S-08 → RESOLVED, S-16 → mitigated.

## Test plan
- TDD: `tests/test_diagnostics.py` (6 тестов: redaction secrets/options, non-sensitive preserved, coordinator counts-only, no-coordinator, `TO_REDACT ⊇ SENSITIVE_KEYS`).
- `PYTHONPATH=. .venv/bin/pytest tests/ -q` → **126 passed**.
- redaction-hook на `diagnostics.py` → чисто.
- `check-audit-reconciliation.sh` → clean.

## Breaking change
Нет. Manifest version не трогается (bump через release workflow по тегу v3.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)